### PR TITLE
fix: rename "Handoff cost" to "HANDOFF.md generation cost" in banner

### DIFF
--- a/claude/hooks/cache-cliff-warn.sh
+++ b/claude/hooks/cache-cliff-warn.sh
@@ -88,7 +88,7 @@ if [ "$rem" -gt 0 ] && [ "$rem" -le 120 ] && [ -f "$ready_sentinel" ]; then
     d_out=$(( cur_out - snap_out ))
     d_in_fmt=$(printf  "%'d" "$d_in"  2>/dev/null || echo "$d_in")
     d_out_fmt=$(printf "%'d" "$d_out" 2>/dev/null || echo "$d_out")
-    delta_line=$'\nHandoff cost: '"${d_in_fmt} in / ${d_out_fmt} out"
+    delta_line=$'\nHANDOFF.md generation cost: '"${d_in_fmt} in / ${d_out_fmt} out"
     rm -f "$stats_file"
   fi
 


### PR DESCRIPTION
## Summary
- Renames the delta cost label in the systemMessage banner from `Handoff cost:` to `HANDOFF.md generation cost:` for clarity — makes it explicit what the in/out token counts refer to.

## Test plan
- [ ] Confirmed via test loop run that banner fires with correct label