### PR TITLE
claude-ds 0.6.0 — proxy + self-healing onboarding + corrected DeepSeek regime model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `wrappers/claude-ds/claude-ds` v0.6.0 — onboarding-and-self-healing release. The wrapper now does for the user nearly everything the previous README told the user to do manually. Specifically:
+
+  - **Config schema versioning + auto-migration.** New `_schema=N` field in the config; the wrapper detects older schemas on launch, backs up the original to `<config>.v<old>.bak`, and migrates forward in place. Newer-than-supported schemas are rejected with a clear "upgrade claude-ds" message rather than silently corrupting data.
+
+  - **Damaged-config detection + non-destructive auto-repair.** Pre-load validator scans every line for `key=value` shape; on any malformed line, the original is backed up to `<config>.broken.<timestamp>.bak`, malformed lines are dropped with a named warning, unknown-key lines are warned and dropped (forward-compat: a future schema will surface them differently), and the file is rewritten with every parseable known key preserved. **No user data is ever lost** — the backup remains until the user removes it.
+
+  - **Lazy-install of the optional proxy sidecar.** When `proxy_effort` is enabled and `claude-ds-proxy.py` is missing on disk, the wrapper attempts a one-time `curl` of the script from `$PROXY_DOWNLOAD_URL` (default: `raw.githubusercontent.com/earchibald/agent-utilities/main/wrappers/claude-ds/claude-ds-proxy.py`). On success the script is placed beside `claude-ds` and execution continues normally. On failure (network, 404, missing curl, write-permission), the wrapper **soft-falls-back** to running with the proxy disabled for that session, prints a single clear warning, and **never mutates the config file**. The user can install python3 / curl / the proxy script later and the next launch picks it up.
+
+  - **`python3` soft-fallback.** When `proxy_effort` is enabled but `python3` is missing on `$PATH`, the wrapper warns once and runs with the proxy disabled for that session — instead of the previous hard-fail. The user is told what to install (or to set `proxy_effort=off` to silence).
+
+  - **API-key liveness validation.** After first-run capture or `--rotate-key`, the wrapper runs a 5-second `POST /v1/messages` liveness probe with `max_tokens=1` against the configured `base_url`. On HTTP 401/403, the user is re-prompted (up to 3 attempts). On network failure or unexpected status, a single advisory line is printed and the config is saved anyway (offline-friendly first-run). On a clean 2xx, the key is silently saved.
+
+  - **`--doctor` end-to-end diagnostics.** New flag prints a 7-step checklist with ✓/✗ markers and actionable next-step text per row: claude on `$PATH`, python3 ≥ 3.8 available, config readable + schema version, secret reference resolvable, API key live against upstream, proxy script presence (when proxy enabled), and per-tier collision lint. Designed so a user with a broken setup never has to ask "what's wrong?" — they just run `--doctor`.
+
+  - **`--rotate-key` alias for `--reset-password`.** The new name reflects what the operation actually does (rotate an API key, not reset a password). Both flags are accepted; both routes preserve the user's existing `proxy_effort` choice across rotation, so rotating a key never silently flips the proxy back to off.
+
+  - **Per-tier collision linter.** On every launch with the proxy enabled, the wrapper computes the resolved wire-level model id for each tier (taking `unlock_auto_mode` and `model_*` overrides into account) and warns the moment two tiers with non-empty `proxy_effort_*` specs map to the same wire id. The warning names the colliding tiers and notes which one will take effect (priority order `small_fast → haiku → sonnet → opus`, opus wins).
+
+  - **Interactive proxy opt-in on first run.** First-run prompt now offers four choices for `proxy_effort` (skip, `auto:high`, `auto:max`, custom), since the proxy is now off by default. Default selection is "skip" (recommended).
+
+  - **Symlink-aware proxy script lookup.** `_claude_ds_realpath` is a small portable readlink-loop (works on macOS BSD `readlink` and Linux GNU `readlink` alike) that canonicalises `${BASH_SOURCE[0]}` before computing the proxy's location. Previously, symlinking `claude-ds` from `~/.local/bin` to a source-tree checkout would leave the proxy unfindable because bash does not auto-resolve `BASH_SOURCE`. Now `ln -s ~/src/agent-utilities/wrappers/claude-ds/claude-ds ~/.local/bin/claude-ds` is sufficient — the proxy is found in the source tree without a second symlink.
+
+- `wrappers/claude-ds/README.md` — full-product README (install, quickstart, "what the wrapper does for you", configuration scenarios, reasoning-effort proxy spec language, secret-reference guide, troubleshooting, developer notes). Reviewed by three Sonnet agents and one (handicapped) Opus agent in competition; the verified-correct findings were applied. Notable applied feedback: explicit symlink-supported callout, security disclosure that the resolved API key lives in the `claude` process environment, restructure to put scenario-based configs *before* the reference table (so users discover the three common shapes first), Linux `systemd --user` orphan-watchdog caveat, and a corrected per-tier collision matrix that handles the `unlock_auto_mode=1` case (where haiku and small_fast collide on `claude-haiku-4-5` rather than all four tiers collapsing onto a single wire id). Opus took the cookies.
+
+### Changed
+
+- **Reasoning-effort proxy: corrected DeepSeek regime model.** Earlier v0.5 versions assumed DeepSeek supported the full Anthropic level set (`minimal`, `low`, `medium`, `high`). Per DeepSeek's compat shim documentation, only three reasoning regimes are actually distinguishable on the wire:
+  1. `none` — `thinking` block absent, no `reasoning_effort` (no reasoning)
+  2. `high` — `thinking: {"type": "enabled"}` present, no `reasoning_effort` *or* `=high` (default reasoning depth — same wire effect either way)
+  3. `max` — `thinking` present **and** `reasoning_effort=max` (maximum depth)
+
+  The proxy's spec language now collapses to `{off, none, high, max, auto, auto:<level>, none=<v>|high=<v>|max=<v>}`. Caller-supplied Anthropic-style values (`low`, `medium`, `xhigh`, `minimal`) are normalised to one of the three regimes rather than passed through (DeepSeek would otherwise reject them silently). The proxy now applies a *transformation* on each request rather than just an injection: `none` strips both `thinking` and `reasoning_effort`; `high` ensures `thinking: {type: enabled}` (preserving any caller-supplied `budget_tokens`) and strips `reasoning_effort`; `max` ensures thinking and sets `reasoning_effort=max`. Auto-bucket thresholds: no thinking → `none`; thinking with budget < 31000 → `high`; thinking with budget ≥ 31000 → `max` (matching `ultrathink` ≈ 31999).
+
+- **Reasoning-effort proxy: now off by default.** DeepSeek already maps claude's `/think`, `/think-hard`, `/ultrathink` commands to its native reasoning regime via the `thinking` block claude already sends, so the proxy adds nothing for normal use. New configs default to `proxy_effort=off`. The proxy is opt-in for users who want to *force* a specific regime regardless of what claude requests (always-max, always-none, per-tier knobs); the first-run flow offers four interactive choices (skip / `auto:high` / `auto:max` / custom).
+
+- **Reasoning-effort proxy: `STRIP_THINKING` env var removed; `proxy_strip_thinking` config key deprecated.** Strip-vs-preserve behaviour is now baked into the regime model itself: the `none` regime strips, `high` and `max` preserve. Setting `proxy_strip_thinking` is silently ignored on load (so old configs don't break); a future schema migration will remove it from rewritten configs.
+
+### Deprecated
+
+- `proxy_strip_thinking` config key. Honoured for read (silently ignored) on load to avoid breaking older configs. The damaged-config repair path drops it with an `unknown key` warning when the parser doesn't recognise it post-migration. Will be cleaned up in a future schema migration.
+
+- `wrappers/claude-ds/claude-ds-proxy.py` — request-rewriting HTTP proxy (Python 3 stdlib, no third-party deps) that translates Anthropic's `thinking.budget_tokens` into DeepSeek's `reasoning_effort` enum on outgoing `/v1/messages` bodies. Resolution is a 2-D matrix keyed by `(spoofed_model_id, source_bucket)` where the source bucket is derived from the request's `thinking` field (`none` when absent or disabled; otherwise `low <4096`, `medium <16384`, `high >=16384` — thresholds aligned with Claude Code's canned `think` / `think hard` / `ultrathink` levels). Per-model and global resolvers accept a small spec language: `off`, `<level>`, `auto`, `auto:<level>` (auto with a fallback for the no-thinking case), and a full per-bucket matrix `none=<v>|low=<v>|medium=<v>|high=<v>`. Streaming SSE bodies are forwarded byte-for-byte under HTTP/1.1 + `Connection: close` so chunked re-encoding isn't needed. The proxy strips the original `thinking` block after injection by default (configurable via `STRIP_THINKING=0`) since DeepSeek's compat shim doesn't accept Anthropic's thinking spec. A daemon-thread orphan watchdog polls `os.getppid()` and exits when the wrapper's PID is reaped (so the proxy doesn't leak after `claude` exits, since `exec claude` replaces the wrapper shell and prevents its EXIT trap from firing).
+
+- Reasoning-effort proxy integration in `wrappers/claude-ds/claude-ds`. New config keys: `proxy_effort` (default `auto`), `proxy_effort_{opus,sonnet,haiku,small_fast}`, `proxy_strip_thinking` (default `1`), `proxy_bind` (default `127.0.0.1`), `proxy_debug`. The wrapper builds an `EFFORT_MAP` of `(wire_id → spec)` from the per-tier configs, binding each tier's spec to the *wire-level* model id of `ANTHROPIC_DEFAULT_<TIER>_MODEL` (so per-tier overrides work whether `unlock_auto_mode=1` is in effect or not). Tier specs are emitted in priority order `small_fast → haiku → sonnet → opus`, so opus wins on wire-id collisions (the default — DeepSeek is single-tier). The proxy is started only when at least one spec is non-empty and not `off`; with `proxy_effort=off` and no per-tier overrides, the wrapper exports `ANTHROPIC_BASE_URL` directly to DeepSeek and never spawns the python child. One-shot env overrides: `CLAUDE_DS_PROXY_EFFORT=off` (skip the proxy for this invocation) and `CLAUDE_DS_PROXY_DEBUG=1` (log injections to stderr). The wrapper reads the bound port via a temporary FIFO with a 5-second timeout, fails fast if the proxy died on startup, and points `ANTHROPIC_BASE_URL` at `http://127.0.0.1:<port>` before `exec claude`.
+
+- `claude_ds_cleanup` consolidated EXIT/INT/TERM trap in `wrappers/claude-ds/claude-ds`. Replaces the prior tmux-only inline trap. Now kills the proxy PID (if spawned) and runs the existing tmux window/pane restoration in a single function. Note: once `exec claude` succeeds the trap can't fire (the shell is replaced), which is why the proxy carries its own orphan watchdog in addition.
+
+### Changed
+
+- `wrappers/claude-ds/claude-ds` version bumped to `0.5.0` for the reasoning-effort proxy. First-run config template now writes a documented block of `# proxy_effort=…` placeholders so users can discover the spec language without reading `--help`. The `--help` output gains a `REASONING-EFFORT PROXY` section covering the source-bucket thresholds, the spec grammar, the per-tier collision rule, and the env-var overrides.
+
 ## [0.4.0] - 2026-05-03
 
 ### Added

--- a/wrappers/claude-ds/README.md
+++ b/wrappers/claude-ds/README.md
@@ -1,0 +1,750 @@
+# claude-ds
+
+> Run [Claude Code](https://docs.anthropic.com/claude/code) against
+> [DeepSeek](https://www.deepseek.com)'s Anthropic-compatible API — with
+> system-keychain / 1Password / Infisical secret refs, schema-versioned
+> config that auto-migrates and auto-repairs, lazy-installed sidecar
+> proxy, end-to-end `--doctor` diagnostics, and per-tier reasoning
+> controls when you want them.
+
+`claude-ds` is a small Bash wrapper plus an optional Python sidecar. It
+exists because pointing Claude Code at a third-party Anthropic-compatible
+endpoint is a tangle of environment variables, model-id gates, schema
+drift, and an incompatible reasoning-depth wire format. `claude-ds`
+makes that one command:
+
+```bash
+claude-ds
+```
+
+The wrapper takes care of:
+
+- prompting for and storing your secret reference on first run
+- testing your API key against DeepSeek before saving
+- migrating older config files forward when the schema changes
+- detecting and auto-repairing damaged configs (with a backup so nothing is lost)
+- lazy-installing the optional reasoning-effort proxy if and when you opt in
+- gracefully falling back when an optional dependency (python3, curl) is missing
+
+If something does go wrong, `claude-ds --doctor` runs an end-to-end
+checklist and tells you exactly what to fix.
+
+---
+
+## Table of contents
+
+- [Why use this](#why-use-this)
+- [Quickstart](#quickstart)
+- [Installation](#installation)
+- [What the wrapper does for you](#what-the-wrapper-does-for-you) — the important section if you'd rather not read the rest
+- [Configuration](#configuration) — start here if you don't know what to set
+- [Secret references](#secret-references)
+- [Reasoning-effort proxy](#reasoning-effort-proxy)
+  - [Per-tier collisions](#per-tier-collisions)
+- [Auto-mode unlock](#auto-mode-unlock)
+- [Per-tier model overrides](#per-tier-model-overrides)
+- [Visual branding (tmux)](#visual-branding-tmux)
+- [Environment variables](#environment-variables)
+- [Troubleshooting](#troubleshooting)
+- [Developer notes](#developer-notes)
+- [License](#license)
+
+---
+
+## Why use this
+
+| Problem | What `claude-ds` does |
+|---|---|
+| Setting `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` by hand on every shell session | Persists a single config file under `$XDG_CONFIG_HOME/claude-ds/`. |
+| Hard-coding API keys in shell rc files or `.env` | Stores a *reference* (`op://`, `system://`, `infisical://`, …) and resolves it on each run. Plaintext is supported but never required. |
+| Claude Code's auto-mode (`--auto` permission classifier) refuses to run on non-Anthropic models | Optional `unlock_auto_mode` flag spoofs the wire-level model id so the gate passes. |
+| `/model default` and tier routing break against single-tier providers | All four tiers (opus / sonnet / haiku / small_fast) are pinned to the configured model by default; per-tier overrides are available. |
+| DeepSeek doesn't honor Anthropic's `thinking.budget_tokens`; Claude Code can't send `reasoning_effort` | A local Python proxy translates between the two — `think hard` → `medium`, `ultrathink` → `high`, etc. — fully configurable, off by `proxy_effort=off`. |
+| Hard to tell at a glance which terminal is talking to DeepSeek vs. real Anthropic | When run inside tmux, the active pane gets a DeepSeek-themed top border and the window name is prefixed `🐋`. |
+| Config schema changes between releases | Schema-versioned (`_schema=N`); old configs are auto-migrated forward with a `.v<old>.bak` backup. |
+| Hand-edited config got broken | `claude-ds` detects malformed lines on launch, backs up the original to `config.broken.<timestamp>.bak`, and rewrites a clean config preserving every parseable key. |
+| "Did I install everything correctly?" | `claude-ds --doctor` checks claude on PATH, python3, proxy script presence, secret-ref resolves, API key live against upstream, and tier-collision lint — printing ✓/✗ with actionable next steps. |
+
+---
+
+## Quickstart
+
+```bash
+# 1. Install (see Installation below for alternatives).
+mkdir -p ~/.local/bin
+curl -fL https://raw.githubusercontent.com/earchibald/agent-utilities/main/wrappers/claude-ds/claude-ds         -o ~/.local/bin/claude-ds
+curl -fL https://raw.githubusercontent.com/earchibald/agent-utilities/main/wrappers/claude-ds/claude-ds-proxy.py -o ~/.local/bin/claude-ds-proxy.py
+chmod +x ~/.local/bin/claude-ds
+
+# 2. First run interactively walks you through:
+#    - secret reference (paste a key directly, or use `system://`,
+#      `op://`, `infisical://` — see Secret references below)
+#    - liveness check against DeepSeek (catches typo'd keys before you save)
+#    - reasoning-effort proxy opt-in (default: off; most users don't need it)
+claude-ds
+
+# 3. That's it. Useful follow-ups:
+claude-ds --doctor       # end-to-end checklist if anything seems wrong
+claude-ds --rotate-key   # rotate the stored API key (alias of --reset-password)
+```
+
+> 💡 **The proxy script doesn't need `chmod +x`** — the wrapper invokes it
+> as `python3 claude-ds-proxy.py`. Only `claude-ds` itself must be
+> executable.
+>
+> 💡 **Symlinking is supported.** `claude-ds` resolves its own symlinks
+> before locating the proxy script, so `ln -s ~/src/agent-utilities/wrappers/claude-ds/claude-ds ~/.local/bin/claude-ds`
+> works — the proxy is found in the source tree without a second symlink.
+> The two files must be siblings *on the real filesystem*, not in
+> `~/.local/bin`.
+>
+> ⚠️ **Your API key lives in the process environment at runtime.**
+> Whichever secret reference scheme you use, the resolved key is exported
+> as `ANTHROPIC_AUTH_TOKEN` to `claude` and to every process `claude`
+> spawns (MCP servers, shell tools, subprocesses). If your threat model
+> includes untrusted MCP servers or tool output, treat the key as
+> ephemeral and rotate regularly. The on-disk config is `chmod 600`, but
+> at-rest protection does not extend to the running process tree.
+
+---
+
+## Installation
+
+### Requirements
+
+| | Required for |
+|---|---|
+| Bash 4+ | the wrapper itself (macOS ships 3.2 — install `bash` via Homebrew, or run with the `/bin/bash` your distro provides) |
+| `claude` CLI on `$PATH` | obvious |
+| Python 3.8+ | only when the reasoning-effort proxy is enabled (the default — set `proxy_effort=off` to skip) |
+| `op` CLI | only for `op://` secret references |
+| `infisical` CLI | only for `infisical://` secret references |
+| `secret-tool` (Linux, libsecret) | only for `system://` references on Linux. macOS uses the built-in `security` command. |
+
+### Manual install
+
+```bash
+mkdir -p ~/.local/bin
+cp wrappers/claude-ds/claude-ds          ~/.local/bin/claude-ds
+cp wrappers/claude-ds/claude-ds-proxy.py ~/.local/bin/claude-ds-proxy.py
+chmod +x ~/.local/bin/claude-ds
+# Both files must share a directory — the wrapper resolves
+# `claude-ds-proxy.py` from the directory of its own real path.
+```
+
+Make sure `~/.local/bin` is on `$PATH`.
+
+### From this repo (development checkout)
+
+```bash
+git clone https://github.com/earchibald/agent-utilities.git
+ln -s "$PWD/agent-utilities/wrappers/claude-ds/claude-ds" ~/.local/bin/claude-ds
+# The proxy does NOT need to be symlinked separately — the wrapper
+# canonicalises its own path with a portable readlink loop, so
+# `dirname(realpath(claude-ds))` lands in the source tree where the proxy
+# already lives.
+```
+
+### Verifying
+
+```bash
+claude-ds --version    # `claude-ds X.Y.Z`, a horizontal rule, then `claude --version`.
+                       # For machine parsing: `claude-ds --version | head -1`.
+claude-ds --help       # full help, paged through $PAGER (falls back to less / more / cat)
+claude-ds --doctor     # end-to-end checklist (claude on PATH, python3, proxy script,
+                       # secret-ref resolves, API key live, tier collisions)
+```
+
+---
+
+## What the wrapper does for you
+
+You should rarely need to read this README beyond the Quickstart.
+`claude-ds` is designed to do its own onboarding, maintenance, and
+self-healing:
+
+| Situation | What `claude-ds` does automatically |
+|---|---|
+| **Fresh install, no config** | Interactively prompts for a secret reference (with helpers for `system://` and `infisical://`), liveness-checks the resulting API key against DeepSeek, and offers an opt-in for the reasoning-effort proxy. |
+| **Old config from a previous version** | Detects the schema version, backs up the original to `config.v<old>.bak`, and migrates forward in place. |
+| **Damaged config** (typo, hand-edit gone wrong) | Detects malformed lines on launch, backs up the original to `config.broken.<timestamp>.bak`, drops the bad lines with a named warning, preserves every parseable key, and continues. Nothing is lost. |
+| **Missing proxy script** | If the proxy is enabled, attempts a one-time `curl` from `raw.githubusercontent.com` next to the wrapper. On success, runs normally. On failure, soft-falls-back to proxy-disabled for the session and warns — the config is never mutated. |
+| **Missing python3** | Soft-fall-back to proxy-disabled for the session, with a single warning telling you what to install. The wrapper still launches `claude` normally. |
+| **Missing curl** | Same soft-fallback, with a different warning. |
+| **Bad API key** | First-run prompt re-asks (up to 3 times). Subsequent launches surface the failure via `--doctor`. |
+| **Symlinked install** | The wrapper resolves its own symlinks before locating the proxy script — so `ln -s ~/src/agent-utilities/wrappers/claude-ds/claude-ds ~/.local/bin/claude-ds` Just Works. |
+| **Per-tier proxy specs that would silently collide** | Linted on every launch; warns the moment two tiers map to the same wire id and tells you which tier wins. |
+| **API key rotation** | `claude-ds --rotate-key` (or `--reset-password`) — interactive, liveness-checked, preserves your `proxy_effort` choice across rotation. |
+| **Anything else seems wrong** | `claude-ds --doctor` walks the full checklist with ✓/✗ and an actionable next step on each failure. |
+
+The rest of this README is reference material. If you only ever read the
+sections above, you should be fine.
+
+---
+
+## Configuration
+
+`claude-ds` reads a single config file:
+
+```
+${XDG_CONFIG_HOME:-$HOME/.config}/claude-ds/config
+```
+
+The file is created on first run with safe defaults and `chmod 600`. It uses
+`key=value` pairs, one per line. Lines beginning with `#` and blank lines are
+ignored — comment a key out to fall back to its built-in default.
+
+### Start here: pick a scenario
+
+Most users want one of these. Copy, adjust the secret reference, save to
+`~/.config/claude-ds/config`, run `claude-ds`. Done.
+
+**A. "Just give me Claude Code on DeepSeek." (the default)**
+
+```ini
+_schema=1
+api_key_ref=op://Private/DeepSeek/credential
+base_url=https://api.deepseek.com/anthropic
+model=deepseek-v4-pro
+proxy_effort=off
+```
+
+DeepSeek's compat shim already maps claude's `/think`, `/think-hard`,
+and `/ultrathink` commands to its native reasoning regime (`high`, or
+`max` for ultrathink-tier budgets). The proxy is **off by default** — no
+sidecar process is spawned, and claude talks to DeepSeek directly.
+
+**B. "I want auto-mode (`--auto` permission classifier) to work."**
+
+```ini
+_schema=1
+api_key_ref=op://Private/DeepSeek/credential
+base_url=https://api.deepseek.com/anthropic
+model=deepseek-v4-pro
+unlock_auto_mode=1
+capabilities=effort,thinking
+proxy_effort=off
+```
+
+Spoofs Claude-canonical model ids so the auto-mode gate passes, and
+advertises `effort` / `thinking` capabilities so `claude` doesn't strip
+them on the way out.
+
+**C. "I want to force a specific reasoning regime regardless of what claude asks for."**
+
+This is when you opt into the proxy. For example, "always reason at max
+on opus, default behaviour everywhere else":
+
+```ini
+_schema=1
+api_key_ref=op://Private/DeepSeek/credential
+unlock_auto_mode=1
+proxy_effort=off            # don't change behaviour for sonnet/haiku/small_fast
+proxy_effort_opus=max       # always reason at max on the opus tier
+```
+
+Or "always at least default reasoning, even on routine requests":
+
+```ini
+proxy_effort=auto:high
+```
+
+Or "save tokens by never reasoning":
+
+```ini
+proxy_effort=none
+```
+
+> ⚠️ Per-tier specs key on the *wire-level* model id, not the tier name.
+> Read the [tier-collision rules](#per-tier-collisions) before mixing
+> per-tier specs — collisions matter most when `unlock_auto_mode` is
+> *off* (all tiers share one wire id) or when `unlock_auto_mode=1` makes
+> haiku and small_fast both map to `claude-haiku-4-5`. `claude-ds` lints
+> for collisions on launch and prints a warning naming the colliding
+> tiers.
+
+### Full config reference
+
+Keys in **bold** change behaviour on every run. The rest are debugging or
+advanced overrides.
+
+| Key | Default | Purpose |
+|---|---|---|
+| `_schema` | `1` | Config schema version. The wrapper migrates older versions forward on launch (with a `.v<old>.bak` backup). |
+| **`api_key_ref`** | *(set on first run)* | Secret reference for the DeepSeek API key. See [Secret references](#secret-references). |
+| **`base_url`** | `https://api.deepseek.com/anthropic` | Upstream Anthropic-compat endpoint. Override to point at a different gateway. |
+| **`model`** | `deepseek-v4-pro` | Default DeepSeek model id sent over the wire. |
+| `model_opus` | *(unset → uses `model`)* | Override wire-level model for the opus tier. |
+| `model_sonnet` | *(unset → uses `model`)* | Override wire-level model for the sonnet tier. |
+| `model_haiku` | *(unset → uses `model`)* | Override wire-level model for the haiku tier. |
+| `model_small_fast` | *(unset → uses `model`)* | Override wire-level model for the small-fast tier. |
+| `capabilities` | *(unset)* | Comma-separated capability list advertised to `claude` per tier. e.g. `effort,thinking,adaptive_thinking,interleaved_thinking`. Set only when the upstream gateway actually supports them. |
+| **`unlock_auto_mode`** | *(unset)* | When `1`, spoofs Claude-canonical model ids to satisfy auto-mode's regex gate. See [Auto-mode unlock](#auto-mode-unlock). |
+| **`proxy_effort`** | `off` | Global default for the [reasoning-effort proxy](#reasoning-effort-proxy). Spec language documented there. The proxy is opt-in — `off` means the wrapper never spawns the Python child. |
+| `proxy_effort_opus` | *(unset)* | Per-tier override for opus. **Subject to wire-id collision** — see [Per-tier collisions](#per-tier-collisions). |
+| `proxy_effort_sonnet` | *(unset)* | Per-tier override for sonnet. Subject to collision. |
+| `proxy_effort_haiku` | *(unset)* | Per-tier override for haiku. Subject to collision. |
+| `proxy_effort_small_fast` | *(unset)* | Per-tier override for the small-fast tier. Subject to collision. |
+| `proxy_bind` | `127.0.0.1` | Interface the proxy listens on. Leave at loopback unless you have a specific reason. |
+| `proxy_debug` | `0` | When `1`, logs every regime application to stderr. |
+
+> 📝 The deprecated `proxy_strip_thinking` key (v0.5) is silently
+> ignored — strip/preserve behaviour is now baked into the regime model
+> (`none` strips, `high`/`max` preserve).
+
+---
+
+## Secret references
+
+`api_key_ref` accepts one of four schemes:
+
+| Scheme | Resolved by | Example |
+|---|---|---|
+| `<bare-key>` | nothing — written to disk as plaintext | `sk-deepseek-abc123…` |
+| `op://VAULT/ITEM/FIELD` | [1Password CLI](https://developer.1password.com/docs/cli) (`op read`) | `op://Private/DeepSeek/credential` |
+| `system://<account>` | OS keychain — `security` on macOS, `secret-tool` on Linux. Service name is `claude-ds`. | `system://default` |
+| `infisical://PROJECT/ENV/PATH#KEY` | [Infisical CLI](https://infisical.com/docs/cli) (`infisical secrets get`) | `infisical://abc123/prod/#DEEPSEEK_API_KEY` |
+
+> ✱ **Shorthand:** for `op`, `system`, and `infisical` you may type the
+> scheme name without `://` (e.g. `system`, `infisical`) and `claude-ds`
+> will append it for you.
+
+### First-run flow
+
+When the config file doesn't exist, `claude-ds` prompts for a reference.
+Two interactive helpers kick in automatically:
+
+- **`system://`** — drops into a numbered selector listing existing keychain
+  entries under service `claude-ds`. Pick by number, type a new account name,
+  or hit enter to be prompted for one. If the chosen account already has a
+  stored secret, it is reused silently; otherwise you are prompted (with
+  asterisk-echoed input) for the key, which is then stored in the keychain.
+- **`infisical://`** — walks an interactive builder asking for project ID,
+  environment slug (default `dev`), folder path (default `/`), and secret key,
+  then constructs the full URI for you.
+
+### Rotating / changing the key
+
+```bash
+claude-ds --reset-password
+```
+
+For `system://<account>` references, the reset flow asks whether to
+**[1]** replace the stored secret while keeping the account name, or
+**[2]** switch to a different account or scheme entirely (with a follow-up
+asking whether to delete the old keychain entry).
+
+For non-system references, the local config reference is forgotten and you
+are re-prompted; **upstream stores (1Password, Infisical) are never touched**.
+
+---
+
+## Reasoning-effort proxy
+
+> **Off by default.** You don't need this for normal use. DeepSeek already
+> maps claude's `/think`, `/think-hard`, and `/ultrathink` into its
+> native reasoning regime via the `thinking` block claude already sends.
+> Enable the proxy only when you want to **force** a specific regime
+> regardless of what claude requests — e.g. always-max for tough work,
+> always-none for token savings, or per-tier knobs.
+
+### How DeepSeek expresses reasoning
+
+DeepSeek's compat shim recognises three reasoning regimes:
+
+| Regime | Wire shape | Behaviour |
+|---|---|---|
+| `none` | `thinking` block absent, no `reasoning_effort` | No reasoning. |
+| `high` | `thinking: {type: enabled}` present, `reasoning_effort` absent (or `=high` — same wire effect) | DeepSeek's default reasoning depth. |
+| `max` | `thinking: {type: enabled}` present **and** `reasoning_effort=max` | Maximum reasoning. |
+
+Anthropic's API uses `thinking.budget_tokens` (an integer) for the same
+idea. The proxy translates between them and **collapses any
+caller-supplied Anthropic-style levels** (`low`, `medium`, `xhigh`,
+etc.) onto these three regimes — DeepSeek would otherwise reject them.
+
+### What the proxy does on each request
+
+For every `POST /v1/messages` it sees:
+
+1. Determine the **source bucket** from the incoming body's `thinking` block:
+   - no thinking block → `none`
+   - thinking enabled, budget `< 31000` → `high`
+   - thinking enabled, budget `>= 31000` → `max` (ultrathink)
+2. Resolve the per-model spec → target regime.
+3. Apply the regime's **transformation** in place:
+   - `none` → strip both `thinking` and `reasoning_effort`
+   - `high` → ensure `thinking: {type: enabled}` (preserving any caller-supplied `budget_tokens`), strip `reasoning_effort`
+   - `max` → ensure `thinking: {type: enabled}`, set `reasoning_effort=max`
+
+### Spec language
+
+The value of `proxy_effort` (and each per-tier `proxy_effort_*`):
+
+| Value | Behaviour |
+|---|---|
+| `off` (or empty) | Pass the body through unchanged. The proxy is a no-op for this model. |
+| `auto` | Mirror the source bucket: `none` → strip, `high` → ensure thinking on, `max` → ensure thinking + max. |
+| `auto:<level>` | Like `auto`, but **upgrade** the no-thinking case to `<level>`. `auto:high` forces thinking on every request; `auto:max` forces full reasoning whenever claude is silent. |
+| `none` | Always strip thinking and reasoning_effort (force no-reasoning). |
+| `high` | Always ensure thinking enabled + drop reasoning_effort (force default reasoning). |
+| `max` | Always ensure thinking + reasoning_effort=max (force maximum reasoning). |
+| `none=<v>\|high=<v>\|max=<v>` | Full per-source-bucket matrix. Clauses are optional; missing buckets pass through unchanged. |
+
+### Resolution order on every request
+
+1. Look up the model id in the per-tier map (built from `proxy_effort_*` and
+   the wire-level model id of each tier). On a hit, use that spec.
+2. Otherwise, fall back to the global `proxy_effort` spec.
+3. If the resolved spec is `off` (or unset), the body is forwarded unchanged.
+4. Otherwise, apply the regime's transformation.
+
+### Enabling the proxy
+
+You can opt in three ways:
+
+```bash
+# (a) Interactive — first-run prompt offers proxy choices
+claude-ds                              # prompts on first run
+
+# (b) One-shot via env var
+CLAUDE_DS_PROXY_EFFORT=auto:high claude-ds
+
+# (c) Persistently in config
+echo "proxy_effort=auto:max" >> ~/.config/claude-ds/config
+```
+
+When the proxy is enabled, `claude-ds` will **lazy-install** the
+sidecar script if it's missing — fetching `claude-ds-proxy.py` from
+the same source the wrapper came from. If the download fails (or
+`curl` is missing, or `python3` is missing), the wrapper soft-falls-back
+to running with the proxy disabled for that session and prints a
+single warning. Your config is never silently mutated.
+
+### Disabling the proxy entirely
+
+```ini
+proxy_effort=off
+# (and leave every per-tier proxy_effort_* unset or off)
+```
+
+When all specs resolve to "off", `claude-ds` skips spawning the Python child
+entirely; `ANTHROPIC_BASE_URL` is exported pointing straight at DeepSeek and
+there is zero proxy overhead.
+
+### One-shot env overrides
+
+```bash
+CLAUDE_DS_PROXY_EFFORT=off claude-ds              # skip the proxy this invocation
+CLAUDE_DS_PROXY_EFFORT=auto:max claude-ds         # opt in for one run
+CLAUDE_DS_PROXY_DEBUG=1 claude-ds                 # log every regime application to stderr
+```
+
+<a id="per-tier-collisions"></a>
+### Per-tier collisions
+
+The proxy keys its lookup table on the *wire-level* model id (the value
+of `ANTHROPIC_DEFAULT_<TIER>_MODEL`), not the tier name. Whenever two
+tiers share a wire id, only one per-tier spec can win for that id.
+
+`claude-ds` writes per-tier specs into the lookup table in the order
+**small_fast → haiku → sonnet → opus** — so for any given wire id, the
+tier later in that order wins on collision.
+
+In practice that means three regimes:
+
+| Configuration | Wire ids per tier | Collisions | Effective rule |
+|---|---|---|---|
+| Default (no `unlock_auto_mode`, no `model_*` overrides) | All four → `deepseek-v4-pro` | All four collide | `proxy_effort_opus` wins for every tier; the others are dead config. |
+| `unlock_auto_mode=1`, no `model_*` overrides | opus → `claude-opus-4-7`, sonnet → `claude-sonnet-4-6`, haiku & small_fast → `claude-haiku-4-5` | haiku ↔ small_fast | opus and sonnet behave independently. `proxy_effort_haiku` wins over `proxy_effort_small_fast` for the haiku/small_fast wire id. |
+| Distinct `model_<tier>` overrides (or `unlock_auto_mode=1` with at least one tier overridden to a unique id) | Four distinct ids | None | All four per-tier specs are independent. |
+
+If you set per-tier specs that you *expect* to be independent, double-check
+which regime you're in. The simplest fix for an unwanted collision is to
+add a `model_<tier>` override that gives the tier its own wire id, or to
+enable `unlock_auto_mode=1` if it isn't already.
+
+---
+
+## Auto-mode unlock
+
+Claude Code's *auto mode* — the permission classifier that auto-approves
+routine tool calls — is gated on the model id matching one of:
+
+```
+claude-opus-4-7
+claude-opus-4-6
+claude-sonnet-4-6
+```
+
+(The provider is *not* checked; just the model name regex.) With the default
+`model=deepseek-v4-pro`, auto mode reports "unavailable for this model".
+
+Setting `unlock_auto_mode=1` makes `claude-ds` advertise spoofed Anthropic
+model ids to claude:
+
+```
+ANTHROPIC_MODEL=claude-opus-4-7
+ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-7
+ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6
+ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5
+ANTHROPIC_SMALL_FAST_MODEL=claude-haiku-4-5
+```
+
+The picker labels (`ANTHROPIC_DEFAULT_*_MODEL_NAME` /
+`ANTHROPIC_DEFAULT_*_MODEL_DESCRIPTION`) are also set to DeepSeek-branded
+strings so `/model` still shows what's actually running over the wire.
+
+Whether this works depends on your gateway: DeepSeek's compat shim accepts
+arbitrary `model` values (it routes by URL+auth) at the time of writing, but
+some gateways reject unknown model ids. If yours does, leave
+`unlock_auto_mode` unset.
+
+---
+
+## Per-tier model overrides
+
+By default, all four tiers (`opus`, `sonnet`, `haiku`, `small_fast`) are
+pinned to the value of `model`. This keeps `/model default` and tier-routing
+working against a single-tier provider.
+
+To run different DeepSeek models per tier, set any subset of:
+
+```ini
+model=deepseek-v4-pro
+model_opus=deepseek-v4-pro
+model_sonnet=deepseek-v4-mid
+model_haiku=deepseek-v4-fast
+model_small_fast=deepseek-v4-fast
+```
+
+Per-tier `model_*` overrides also win over the auto-mode-unlock spoofed
+ids, so you can have genuine claude-opus-4-7 spoofing on opus while running
+real DeepSeek ids on the cheaper tiers.
+
+---
+
+## Visual branding (tmux)
+
+When `claude-ds` is launched inside tmux, the active pane gets a DeepSeek
+indigo top border with a 🐋 badge:
+
+```
+─🐋 DEEPSEEK ─ model: deepseek-v4-pro · wire id: claude-opus-4-7 (spoofed for auto-mode) ────
+```
+
+The window name in tmux's status bar is also prefixed `🐋 ` so the marker
+is visible from anywhere.
+
+To skip branding (e.g. for headless `claude -p` runs), set:
+
+```bash
+CLAUDE_DS_NO_BRANDING=1 claude-ds -p "summarise this file"
+```
+
+If the indigo (`#4D6BFE`) looks washed-out in iTerm2, lower the
+**Minimum Contrast** slider in `Profiles → Colors`. Also confirm your
+tmux config has `terminal-features` with `RGB` set for your `$TERM` so
+24-bit color passes through.
+
+---
+
+## Environment variables
+
+Variables `claude-ds` **reads** (one-shot overrides):
+
+| Variable | Effect |
+|---|---|
+| `CLAUDE_DS_PROXY_EFFORT` | Overrides `proxy_effort` for this invocation. `off` skips the proxy. |
+| `CLAUDE_DS_PROXY_DEBUG` | When `1`, the proxy logs each injection decision to stderr. |
+| `CLAUDE_DS_NO_BRANDING` | When set, suppresses tmux branding. |
+| `INFISICAL_TOKEN` | Used by the Infisical CLI when resolving `infisical://` refs without an interactive login. |
+| `XDG_CONFIG_HOME` | Where the config file lives (`$XDG_CONFIG_HOME/claude-ds/config`). |
+| `PAGER` | Used by `--help` (falls back to `less -RF`, then `more`, then `cat`). |
+| `TMUX`, `TMUX_PANE` | Auto-detected for the visual-branding block. |
+
+Variables `claude-ds` **exports** to `claude`:
+
+| Variable | Set when |
+|---|---|
+| `ANTHROPIC_BASE_URL` | always (points at the proxy when enabled, DeepSeek directly otherwise) |
+| `ANTHROPIC_AUTH_TOKEN` | always (the resolved API key) |
+| `ANTHROPIC_MODEL` | always |
+| `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL` | always |
+| `ANTHROPIC_SMALL_FAST_MODEL` | always |
+| `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL_NAME` / `_DESCRIPTION` | when `unlock_auto_mode=1` (DeepSeek-labelled picker text) |
+| `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL_SUPPORTED_CAPABILITIES` | when `capabilities=` is set |
+| `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` | always |
+| `CLAUDE_DISABLE_NONSTREAMING_FALLBACK=1` | always |
+| `CLAUDE_DS=1` | always (marker — useful for hooks / statusline scripts; e.g. `if [[ -n "$CLAUDE_DS" ]]; then echo "DeepSeek session"; fi`) |
+
+---
+
+## Troubleshooting
+
+**`claude-ds: python3 not found`**
+The reasoning-effort proxy needs Python 3.8+. Install it, or set
+`proxy_effort=off` (and clear all per-tier `proxy_effort_*`) to bypass.
+
+**`claude-ds: reasoning-effort proxy failed to start`**
+Re-run with the env override `CLAUDE_DS_PROXY_DEBUG=1 claude-ds` — the
+proxy's startup error will print to stderr. (`proxy_debug=1` is the
+config-file equivalent and requires editing the file before re-running.)
+Common causes: a malformed spec in `proxy_effort_*` (the parser names the
+offending clause), or `proxy_bind` pointing at an interface you don't have.
+
+**Auto mode says "unavailable for this model"**
+Set `unlock_auto_mode=1`. If your gateway rejects spoofed claude-* ids,
+auto mode is genuinely unavailable on that provider.
+
+**`/model default` shows the same DeepSeek model for every tier**
+That's expected on a single-tier provider. Set distinct `model_<tier>`
+overrides if your DeepSeek plan has tiered models.
+
+**My API key didn't get persisted**
+You probably entered it as a bare plaintext key. Plaintext is stored
+verbatim in the config (`chmod 600`); to use the OS keychain instead, run
+`claude-ds --reset-password` and enter `system://`.
+
+**The tmux border is invisible / washed out**
+Lower iTerm2's **Minimum Contrast** slider (`Profiles → Colors`). For
+non-iTerm terminals, ensure your `tmux.conf` has `terminal-features` with
+`RGB` for your `$TERM`.
+
+**The proxy keeps running after I quit claude**
+The proxy has an orphan watchdog (in `claude-ds-proxy.py`) that polls
+`os.getppid()` every 2 seconds and exits when reparented to PID 1
+(init/launchd). On macOS and on Linux without user-level subreapers
+this is reliable.
+
+> ⚠️ **Linux + `systemd --user` caveat.** When `systemd --user` is the
+> session leader, orphans may be reparented to the user-systemd PID
+> instead of PID 1, and the watchdog won't trigger. Check with:
+> ```
+> ps -o ppid= -p "$(pgrep -f claude-ds-proxy.py)"
+> ```
+> If that prints anything other than `1`, kill manually with
+> `pkill -f claude-ds-proxy.py`. (We're tracking a fix using
+> `prctl(PR_SET_PDEATHSIG)` on Linux — PRs welcome.)
+
+---
+
+## Developer notes
+
+> **Status:** `claude-ds` currently lives inside the
+> [`earchibald/agent-utilities`](https://github.com/earchibald/agent-utilities)
+> monorepo as a single-purpose wrapper. It is expected to graduate to its
+> own repository in the near future; when that happens, this directory
+> will be reduced to a stub pointing at the new location, and the canonical
+> source will move. Until then, **PRs and issues should target
+> `earchibald/agent-utilities`**.
+
+### Repository layout
+
+```
+wrappers/claude-ds/
+├── claude-ds              # Bash wrapper (entry point)
+├── claude-ds-proxy.py     # Python 3 stdlib HTTP proxy (request rewriter)
+└── README.md              # this file
+```
+
+### Internal architecture
+
+```
+                                     ┌───────────────────────┐
+   user ─► claude-ds (bash)          │   secretref library   │
+            │                        │   (op:// system://    │
+            │ resolve ref ───────────►   infisical://)       │
+            │                        └───────────────────────┘
+            │ build effort map from per-tier configs
+            │ spawn proxy if needed
+            │
+            ▼
+   ANTHROPIC_BASE_URL=http://127.0.0.1:PORT
+            │
+            ▼
+   exec claude  ──HTTP──► claude-ds-proxy.py ──HTTPS──► DeepSeek /anthropic
+                          ├─ inject reasoning_effort
+                          ├─ strip thinking block
+                          └─ stream response back
+```
+
+The Bash script is structured as four blocks: (1) arg parsing and `--help`,
+(2) the embedded reusable `secretref` library, (3) config load + spawn
+logic, (4) `exec claude`. The proxy is only spawned when at least one
+effort spec is non-empty/non-off; otherwise the wrapper points
+`ANTHROPIC_BASE_URL` straight at DeepSeek and skips the Python child.
+
+### `secretref` library
+
+The reusable secret-reference resolver lives between `# BEGIN secretref`
+and `# END secretref` markers in `claude-ds`. It is intentionally
+copy-paste-friendly: drop the block into another wrapper, set
+`SECRETREF_KEYCHAIN_SERVICE` and `SECRETREF_LOG_PREFIX`, and you have the
+same `op:// / system:// / infisical://` plumbing for free.
+
+### Testing the proxy in isolation
+
+```bash
+# Spawn against a fake upstream and probe with curl
+python3 -c "
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+class H(BaseHTTPRequestHandler):
+    def log_message(*a, **k): pass
+    def do_POST(self):
+        n = int(self.headers.get('Content-Length','0'))
+        body = self.rfile.read(n)
+        self.send_response(200); self.end_headers(); self.wfile.write(body)
+import sys; s = ThreadingHTTPServer(('127.0.0.1', 0), H)
+print(s.server_address[1], flush=True); s.serve_forever()
+" &
+UP=$!
+sleep 0.2
+UPORT=$(lsof -p $UP -a -iTCP -sTCP:LISTEN -P -n | awk 'NR==2{split($9,a,":"); print a[2]}')
+
+UPSTREAM_BASE_URL="http://127.0.0.1:$UPORT" \
+EFFORT_DEFAULT=auto \
+EFFORT_MAP="claude-opus-4-7=high" \
+PROXY_DEBUG=1 \
+  python3 claude-ds-proxy.py
+```
+
+### Running against a development checkout
+
+```bash
+git clone https://github.com/earchibald/agent-utilities.git
+cd agent-utilities
+./wrappers/claude-ds/claude-ds --version
+```
+
+The wrapper resolves the proxy script via `dirname` of `BASH_SOURCE[0]`
+(after symlink resolution), so running it directly from the source tree
+works without installation.
+
+### Contributing
+
+PRs welcome against [`earchibald/agent-utilities`](https://github.com/earchibald/agent-utilities).
+Please:
+
+- Update [`CHANGELOG.md`](../../CHANGELOG.md) under `[Unreleased]` for any
+  user-visible behaviour change.
+- For Bash changes: keep `set -euo pipefail` semantics intact; keep the
+  `secretref` block self-contained (no external function calls); if you
+  touch the `tmux` branding block, verify cleanup still runs in both
+  single-pane and multi-pane windows.
+- For Python changes: stdlib only. The proxy must remain a single file
+  with no install step.
+
+### Versioning
+
+`claude-ds` uses [SemVer](https://semver.org). The version is the
+`VERSION="X.Y.Z"` constant near the top of the wrapper; bump it when you
+release. The CHANGELOG follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+---
+
+## License
+
+Same as the parent `agent-utilities` repository. See the repository root
+for license information.

--- a/wrappers/claude-ds/claude-ds
+++ b/wrappers/claude-ds/claude-ds
@@ -31,12 +31,31 @@
 
 set -euo pipefail
 
-VERSION="0.4.0"
+VERSION="0.6.0"
 CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claude-ds"
 CONFIG_FILE="$CONFIG_DIR/config"
 KEYCHAIN_SERVICE="claude-ds"
 DEFAULT_BASE_URL="https://api.deepseek.com/anthropic"
 DEFAULT_MODEL="deepseek-v4-pro"
+# Config-file schema version. Bump on incompatible changes; add a migration
+# entry in `migrate_config` for each step. Migrations are applied in order
+# from the file's recorded version up to CURRENT_SCHEMA, with a backup
+# written before any mutation.
+CURRENT_SCHEMA=1
+# Where to fetch the proxy script from when it is missing on disk and the
+# user has the proxy enabled. Pinned to `main` for now; once the project
+# graduates to its own repo this should pin to a tagged release.
+PROXY_DOWNLOAD_URL="https://raw.githubusercontent.com/earchibald/agent-utilities/main/wrappers/claude-ds/claude-ds-proxy.py"
+# Known config keys (used by the validator and the damaged-config repair).
+# Anything in the config file outside this list is preserved with a warning.
+KNOWN_CONFIG_KEYS=(
+  _schema
+  api_key_ref base_url model
+  model_opus model_sonnet model_haiku model_small_fast
+  capabilities unlock_auto_mode
+  proxy_effort proxy_effort_opus proxy_effort_sonnet proxy_effort_haiku proxy_effort_small_fast
+  proxy_strip_thinking proxy_bind proxy_debug
+)
 
 # Print a horizontal rule sized to the terminal width (fallback 78). Used to
 # separate claude-ds-owned output from forwarded `claude` output. Uses U+2500
@@ -53,10 +72,12 @@ print_rule() {
 
 # ---- arg parsing: pull out our flags, forward the rest --------------------
 RESET=0
+DOCTOR=0
 PASSTHROUGH=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --reset-password) RESET=1 ;;
+    --reset-password|--rotate-key) RESET=1 ;;
+    --doctor)                      DOCTOR=1 ;;
     --) shift; PASSTHROUGH+=("$@"); break ;;
     *) PASSTHROUGH+=("$1") ;;
   esac
@@ -100,16 +121,24 @@ for arg in ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}; do
 claude-ds — wrapper that runs `claude` against DeepSeek's Anthropic-compatible API.
 
 USAGE
-  claude-ds [--reset-password] [--help | -h] [--version | -V] [claude args...]
+  claude-ds [--rotate-key | --reset-password] [--doctor]
+            [--help | -h] [--version | -V] [claude args...]
 
 claude-ds-specific flags
+  --rotate-key,
   --reset-password    Clear / rotate the stored API key reference. For
                       `system://` references, asks whether to (1) change the
                       key for the existing account or (2) switch to a
                       different account / scheme (with an option to delete
                       or keep the old keychain entry). For other schemes,
                       forgets the local reference (upstream stores are
-                      never touched).
+                      never touched). The new key is liveness-checked
+                      against the configured base_url before saving.
+  --doctor            Run end-to-end diagnostics: claude on PATH, python3
+                      available, proxy script present, config readable
+                      and validated, secret reference resolvable, API key
+                      live, tier-collision warnings. Prints a checklist
+                      then exits.
   --version, -V       Print claude-ds version, plus `claude --version`.
   --help, -h          Print this help, then forward to `claude --help`.
 
@@ -166,17 +195,69 @@ SUPPORTED SECRET-REFERENCE SCHEMES
 
 CONFIGURATION
   Config file:  ${XDG_CONFIG_HOME:-$HOME/.config}/claude-ds/config
+  Schema:       _schema=1 (auto-migrated forward; old configs are backed
+                up to <config>.v0.bak before being upgraded). Damaged
+                configs are detected on load, backed up to
+                <config>.broken.<timestamp>.bak, and auto-repaired
+                preserving every parseable key.
   Keys:         api_key_ref, base_url, model,
                 model_opus, model_sonnet, model_haiku, model_small_fast,
-                capabilities, unlock_auto_mode
+                capabilities, unlock_auto_mode,
+                proxy_effort, proxy_effort_{opus,sonnet,haiku,small_fast},
+                proxy_bind, proxy_debug
   Defaults:     base_url=https://api.deepseek.com/anthropic
                 model=deepseek-v4-pro
-                model_{opus,sonnet,haiku,small_fast} = <model>  (all tiers
-                  pinned to the same DeepSeek model so `/model default` /
-                  auto routing in `claude` doesn't break — DeepSeek is
-                  single-tier from Claude Code's perspective)
+                model_{opus,sonnet,haiku,small_fast} = <model>
                 capabilities = (unset; opt-in)
                 unlock_auto_mode = (unset; opt-in)
+                proxy_effort = auto    (auto-derive from claude's thinking)
+                proxy_effort_<tier> = (unset; falls through to proxy_effort)
+                proxy_bind = 127.0.0.1
+                proxy_debug = 0
+
+REASONING-EFFORT PROXY
+  DeepSeek's compat shim recognises three reasoning regimes:
+    none    — `thinking` block ABSENT, no `reasoning_effort`. No reasoning.
+    high    — `thinking: {type:enabled}` PRESENT, no reasoning_effort
+              (or =high — same wire effect). DeepSeek's default depth.
+    max     — `thinking` PRESENT *and* `reasoning_effort=max`. Maximum.
+  Anthropic's wire format uses `thinking.budget_tokens` (an integer).
+  claude-ds spawns a small local proxy that translates between them and
+  collapses any caller-supplied Anthropic levels (low/medium/xhigh/etc.)
+  onto the three regimes above, since DeepSeek would otherwise reject
+  them.
+
+  Auto-bucket (`proxy_effort=auto`):
+    no thinking block        → "none"  (no reasoning)
+    thinking, budget <  31k  → "high"  (default reasoning)
+    thinking, budget >= 31k  → "max"   (ultrathink → maximum reasoning)
+
+  Per-tier overrides bind a spec to the *wire-level* model id of that
+  tier (the value of ANTHROPIC_DEFAULT_<TIER>_MODEL). Tier specs are
+  applied small_fast → haiku → sonnet → opus, so opus wins on wire-id
+  collisions; if a real collision is detected at startup, claude-ds
+  prints a one-line linter warning naming the colliding tiers.
+
+  Spec language (config value):
+    auto             — derive regime from claude's thinking block (default)
+    auto:<level>     — same, but use <level> when claude sends no thinking
+                       (e.g. `auto:high` → always at least default reasoning;
+                       `auto:max` → always max reasoning when claude is silent)
+    off              — pass the body through unchanged for this model
+    none             — strip thinking, return non-reasoning response
+    high             — ensure thinking is enabled (no reasoning_effort)
+    max              — ensure thinking + reasoning_effort=max
+    none=<v>|high=<v>|max=<v>
+                     — full per-source-bucket matrix; clauses are optional,
+                       unlisted buckets pass through unchanged
+
+  Disable the proxy entirely by setting `proxy_effort=off` and leaving
+  every per-tier `proxy_effort_*` unset (or off). Then claude talks to
+  DeepSeek directly, no python child involved.
+
+  Env-var overrides (one-shot, no config edit):
+    CLAUDE_DS_PROXY_EFFORT=off       skip the proxy for this invocation
+    CLAUDE_DS_PROXY_DEBUG=1          log injections to stderr
 
 UNLOCKING AUTO MODE (--auto / permission classifier)
   Claude Code's "auto mode" — the permission classifier that auto-approves
@@ -681,6 +762,288 @@ secretref_reset_local() {
 # END secretref
 # ============================================================================
 
+# ============================================================================
+# BEGIN onboarding — config validation, migration, lazy-install helpers
+# ----------------------------------------------------------------------------
+# This block exists so that **the user does not have to manually maintain
+# claude-ds**. The wrapper detects and self-heals across:
+#
+#   - schema migrations    (add `_schema=N`; bump on incompatible changes)
+#   - damaged config       (back up, preserve every parseable key, repair)
+#   - missing proxy script (fetch from $PROXY_DOWNLOAD_URL, else degrade)
+#   - missing python3      (degrade to proxy_effort=off for this run)
+#   - bad API key          (validate against upstream after capture)
+#   - silent collisions    (lint per-tier specs and warn before launch)
+#
+# All of these run idempotently on every launch; success is silent, only
+# real problems print to stderr.
+
+_cds_log()  { echo "claude-ds: $*" >&2; }
+_cds_warn() { echo "claude-ds: ⚠ $*" >&2; }
+_cds_die()  { _cds_warn "$*"; exit 1; }
+
+# Is `key` in the KNOWN_CONFIG_KEYS list?
+_cds_is_known_key() {
+  local k="$1" known
+  for known in "${KNOWN_CONFIG_KEYS[@]}"; do
+    [[ "$k" == "$known" ]] && return 0
+  done
+  return 1
+}
+
+# Validate the config file structure. Echoes one of:
+#   ok           — every line is well-formed
+#   damaged      — at least one non-comment, non-blank line is malformed,
+#                  or a known key has an unparseable value
+# Pure inspection — never modifies the file.
+_cds_validate_config_file() {
+  local file="$1" line lineno=0 status="ok"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    ((lineno++)) || true
+    case "$line" in
+      ""|\#*|" "*\#*) continue ;;
+    esac
+    # Accept lines of the form `key=value` where key is a valid identifier.
+    if [[ ! "$line" =~ ^[a-zA-Z_][a-zA-Z0-9_]*= ]]; then
+      _cds_warn "config line $lineno is malformed: $(printf '%q' "$line")"
+      status="damaged"
+    fi
+  done < "$file"
+  printf '%s' "$status"
+}
+
+# Repair a damaged config in-place without losing user data.
+# Strategy:
+#   1. Back up the original to config.broken.YYYYMMDDHHMMSS.bak.
+#   2. Re-parse the file, keeping only valid `key=value` lines whose key
+#      is in KNOWN_CONFIG_KEYS (unknown keys are warned and dropped, since
+#      they would otherwise persist forever).
+#   3. Rewrite the config file with the surviving keys, preserving values
+#      verbatim, and ensuring `_schema=$CURRENT_SCHEMA` is present.
+# Idempotent — calling this on an already-clean file is a no-op (other
+# than rewriting it in canonical form).
+_cds_repair_config_file() {
+  local file="$1"
+  local stamp; stamp=$(date +%Y%m%d%H%M%S)
+  local backup="$file.broken.$stamp.bak"
+  cp -p "$file" "$backup" || _cds_die "could not back up damaged config to $backup"
+  _cds_warn "damaged config detected — backed up original to $backup"
+
+  local -a kept_keys=() kept_vals=()
+  local line lineno=0 k v
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    ((lineno++)) || true
+    case "$line" in
+      ""|\#*|" "*\#*) continue ;;
+    esac
+    if [[ ! "$line" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)=(.*)$ ]]; then
+      _cds_warn "  dropping malformed line $lineno: $(printf '%q' "$line")"
+      continue
+    fi
+    k="${BASH_REMATCH[1]}"; v="${BASH_REMATCH[2]}"
+    if ! _cds_is_known_key "$k"; then
+      _cds_warn "  dropping unknown key '$k' (line $lineno) — not in this version's schema"
+      continue
+    fi
+    # Preserve last write of each key (typical config-file semantics).
+    local i found=-1
+    for i in "${!kept_keys[@]}"; do
+      [[ "${kept_keys[$i]}" == "$k" ]] && found=$i && break
+    done
+    if [[ "$found" -ge 0 ]]; then
+      kept_vals[$found]="$v"
+    else
+      kept_keys+=("$k"); kept_vals+=("$v")
+    fi
+  done < "$file"
+
+  # Ensure `_schema` is set to the current version after repair.
+  local i schema_seen=0
+  for i in "${!kept_keys[@]}"; do
+    if [[ "${kept_keys[$i]}" == "_schema" ]]; then
+      kept_vals[$i]="$CURRENT_SCHEMA"
+      schema_seen=1
+      break
+    fi
+  done
+  if [[ "$schema_seen" -eq 0 ]]; then
+    kept_keys=("_schema" "${kept_keys[@]}")
+    kept_vals=("$CURRENT_SCHEMA" "${kept_vals[@]}")
+  fi
+
+  umask 077
+  {
+    printf '# claude-ds config — repaired %s\n' "$(date '+%Y-%m-%d %H:%M:%S')"
+    printf '# Original (damaged) backed up at: %s\n' "$backup"
+    printf '#\n'
+    for i in "${!kept_keys[@]}"; do
+      printf '%s=%s\n' "${kept_keys[$i]}" "${kept_vals[$i]}"
+    done
+  } > "$file"
+  chmod 600 "$file"
+  _cds_log "repaired config — preserved ${#kept_keys[@]} key(s); see $backup for the original."
+}
+
+# Read `_schema` from the config file. Echoes the integer, or `0` if the
+# field is absent (legacy / pre-versioned configs).
+_cds_read_schema() {
+  local file="$1" line k v
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      ""|\#*) continue ;;
+    esac
+    if [[ "$line" =~ ^_schema=([0-9]+)[[:space:]]*$ ]]; then
+      printf '%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done < "$file"
+  printf '0'
+}
+
+# Migrate the config forward from its recorded schema to CURRENT_SCHEMA.
+# Each step is an additive, no-op-if-already-applied transformation; we
+# always back up to config.v$old.bak before the first mutating step. New
+# schema versions get a new `case` clause below.
+_cds_migrate_config() {
+  local file="$1" from to
+  from=$(_cds_read_schema "$file")
+  to=$CURRENT_SCHEMA
+  if [[ "$from" -eq "$to" ]]; then
+    return 0
+  fi
+  if [[ "$from" -gt "$to" ]]; then
+    _cds_die "config schema is v$from but this claude-ds only understands up to v$to. Upgrade claude-ds, or back up + remove $file to start fresh."
+  fi
+  local backup="$file.v${from}.bak"
+  cp -p "$file" "$backup" || _cds_die "could not back up config to $backup before migration"
+
+  local cur="$from"
+  while [[ "$cur" -lt "$to" ]]; do
+    case "$cur" in
+      0)
+        # 0→1: introduce explicit `_schema=1`. No other key changes from
+        # pre-versioned 0.5.x configs; the v0.6.0 schema is a superset.
+        # If the file already contains a malformed `_schema=` line it was
+        # caught earlier by the validator; here we only add or replace.
+        local tmp; tmp=$(mktemp)
+        {
+          printf '_schema=1\n'
+          # Strip any pre-existing _schema= lines (defensive — the
+          # validator should have caught duplicates, but a hand-edit
+          # could produce them).
+          grep -v '^_schema=' "$file" || true
+        } > "$tmp"
+        mv "$tmp" "$file"
+        chmod 600 "$file"
+        ;;
+      *)
+        _cds_die "no migration registered for schema v$cur → v$((cur+1))"
+        ;;
+    esac
+    cur=$((cur+1))
+  done
+  _cds_log "upgraded config from schema v$from to v$to (backup at $backup)."
+}
+
+# Check the upstream API key for liveness. Single 5-second POST to
+# $base_url/v1/messages with max_tokens=1. Curl absence or network
+# failure is treated as advisory (not fatal) so first-run flows still
+# work offline.
+#
+# Args: <token> <base_url> <model>. Echoes one of:
+#   ok          — got a 2xx response
+#   unauth      — got 401 / 403 (key is bad or wrong endpoint)
+#   skipped     — curl missing
+#   network     — couldn't reach upstream (timeout, DNS, etc.)
+#   advisory:N  — got a different non-2xx HTTP code N (treat as advisory)
+_cds_validate_api_key() {
+  local token="$1" base_url="$2" model="$3"
+  command -v curl >/dev/null 2>&1 || { printf 'skipped'; return 0; }
+  local body http_code
+  body='{"model":"'"$model"'","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}'
+  http_code=$(
+    curl -s -o /dev/null -w '%{http_code}' \
+      --max-time 5 \
+      -X POST "$base_url/v1/messages" \
+      -H "Content-Type: application/json" \
+      -H "x-api-key: $token" \
+      -H "anthropic-version: 2023-06-01" \
+      -H "Authorization: Bearer $token" \
+      -d "$body" 2>/dev/null
+  ) || { printf 'network'; return 0; }
+  case "$http_code" in
+    2*) printf 'ok' ;;
+    401|403) printf 'unauth' ;;
+    000) printf 'network' ;;
+    *) printf 'advisory:%s' "$http_code" ;;
+  esac
+}
+
+# Lazy-install the proxy script if it's missing on disk and the user has
+# the proxy enabled. Echoes one of:
+#   present     — script is already there, nothing to do
+#   downloaded  — fetched successfully
+#   failed      — download attempted and failed (caller should soft-fall-back)
+#   skipped     — curl absent (caller should soft-fall-back)
+_cds_ensure_proxy_script() {
+  local target="$1"
+  [[ -f "$target" ]] && { printf 'present'; return 0; }
+  command -v curl >/dev/null 2>&1 || { printf 'skipped'; return 0; }
+  local target_dir; target_dir=$(dirname "$target")
+  if ! mkdir -p "$target_dir" 2>/dev/null; then
+    printf 'failed'; return 0
+  fi
+  if curl -fsSL --max-time 10 "$PROXY_DOWNLOAD_URL" -o "$target.partial" 2>/dev/null; then
+    mv "$target.partial" "$target"
+    printf 'downloaded'
+  else
+    rm -f "$target.partial" 2>/dev/null || true
+    printf 'failed'
+  fi
+}
+
+# Lint per-tier proxy specs for silent collisions. Args: the resolved
+# wire-level model id of each tier (in the order opus/sonnet/haiku/small_fast)
+# followed by the per-tier specs in the same order. Prints a single warning
+# block to stderr if any collision is detected, listing what will and won't
+# take effect. Pure inspection.
+_cds_lint_collisions() {
+  local opus_id="$1" sonnet_id="$2" haiku_id="$3" small_id="$4"
+  local opus_spec="$5" sonnet_spec="$6" haiku_spec="$7" small_spec="$8"
+  local -a tiers=(opus sonnet haiku small_fast)
+  local -a ids=("$opus_id" "$sonnet_id" "$haiku_id" "$small_id")
+  local -a specs=("$opus_spec" "$sonnet_spec" "$haiku_spec" "$small_spec")
+  # Group tiers by wire id.
+  local i j wid
+  local -a warned_ids=()
+  for i in "${!ids[@]}"; do
+    wid="${ids[$i]}"
+    # Only consider tiers that actually have a non-empty per-tier spec.
+    [[ -z "${specs[$i]}" || "${specs[$i]}" == "off" ]] && continue
+    # Skip if we already warned about this wire id.
+    local already=0 w
+    for w in "${warned_ids[@]}"; do
+      [[ "$w" == "$wid" ]] && already=1 && break
+    done
+    [[ "$already" -eq 1 ]] && continue
+    # Find all OTHER tiers with the same wire id and a non-empty spec.
+    local -a colliders=("${tiers[$i]}=${specs[$i]}")
+    for j in "${!ids[@]}"; do
+      [[ "$j" -le "$i" ]] && continue
+      [[ "${ids[$j]}" != "$wid" ]] && continue
+      [[ -z "${specs[$j]}" || "${specs[$j]}" == "off" ]] && continue
+      colliders+=("${tiers[$j]}=${specs[$j]}")
+    done
+    if [[ "${#colliders[@]}" -gt 1 ]]; then
+      _cds_warn "tier-spec collision on wire id '$wid': ${colliders[*]} — only the latest in {small_fast → haiku → sonnet → opus} order will take effect."
+      warned_ids+=("$wid")
+    fi
+  done
+}
+
+# END onboarding
+# ============================================================================
+
 # ---- claude-ds: wire the lib --------------------------------------------
 SECRETREF_KEYCHAIN_SERVICE="$KEYCHAIN_SERVICE"
 SECRETREF_LOG_PREFIX="claude-ds"
@@ -688,55 +1051,213 @@ SECRETREF_LOG_PREFIX="claude-ds"
 # ---- first-run / reset prompt ---------------------------------------------
 write_config() {
   local ref="$1"
+  local proxy_choice="${2:-off}"   # "off" | "auto" | "auto:high" | "auto:max" | …
   umask 077
   mkdir -p "$CONFIG_DIR"
   chmod 700 "$CONFIG_DIR"
-  # Per-tier model_* keys are written as comments by default. DeepSeek is a
-  # single-tier provider from Claude Code's perspective, so the runtime maps
-  # all four tier vars (opus/sonnet/haiku/small_fast) to `model` unless the
-  # user uncomments and sets a tier explicitly. capabilities= is also commented
-  # out — leave unset to let the runtime decide; uncomment + populate (e.g.
-  # `effort,thinking`) only if the upstream gateway actually supports them.
   {
+    printf '_schema=%s\n'               "$CURRENT_SCHEMA"
     printf 'api_key_ref=%s\n'           "$ref"
     printf 'base_url=%s\n'              "$DEFAULT_BASE_URL"
     printf 'model=%s\n'                 "$DEFAULT_MODEL"
+    printf '\n'
+    printf '# Per-tier model overrides — DeepSeek is single-tier from claude'\''s\n'
+    printf '# perspective, so all four tiers default to `model` above. Uncomment\n'
+    printf '# and set if your DeepSeek plan exposes tiered models.\n'
     printf '# model_opus=%s\n'          "$DEFAULT_MODEL"
     printf '# model_sonnet=%s\n'        "$DEFAULT_MODEL"
     printf '# model_haiku=%s\n'         "$DEFAULT_MODEL"
     printf '# model_small_fast=%s\n'    "$DEFAULT_MODEL"
-    printf '# capabilities=\n'
+    printf '\n'
+    printf '# Auto-mode unlock — set to 1 to spoof Claude-canonical model ids\n'
+    printf '# so claude'\''s `--auto` permission classifier accepts the session.\n'
+    printf '# Also opt into capabilities advertised to claude:\n'
     printf '# unlock_auto_mode=1\n'
+    printf '# capabilities=effort,thinking\n'
+    printf '\n'
+    printf '# ---- Reasoning-effort proxy ---------------------------------------\n'
+    printf '#\n'
+    printf '# DeepSeek recognises 3 reasoning regimes:\n'
+    printf '#   none    — no thinking, no reasoning_effort  (no reasoning)\n'
+    printf '#   high    — thinking enabled, no reasoning_effort  (default depth)\n'
+    printf '#   max     — thinking enabled + reasoning_effort=max  (max depth)\n'
+    printf '#\n'
+    printf '# claude already sets `thinking` correctly for its native\n'
+    printf '# /think, /think-hard, /ultrathink commands, which DeepSeek maps to\n'
+    printf '# `high` natively — so for normal use the proxy adds nothing.\n'
+    printf '# Enable it only when you want to FORCE a specific regime regardless\n'
+    printf '# of what claude requests (e.g. always-max for tough work, always-\n'
+    printf '# none to save tokens, or per-tier knobs).\n'
+    printf '#\n'
+    printf '# Spec language for proxy_effort and proxy_effort_<tier>:\n'
+    printf '#   off            — passthrough; do not modify the request (default)\n'
+    printf '#   auto           — derive regime from claude'\''s thinking block\n'
+    printf '#   auto:<level>   — like auto, but force <level> when claude sends\n'
+    printf '#                    no thinking block. e.g. `auto:high` forces\n'
+    printf '#                    thinking on every request.\n'
+    printf '#   none           — strip thinking, no reasoning\n'
+    printf '#   high           — ensure thinking enabled, default reasoning\n'
+    printf '#   max            — ensure thinking + reasoning_effort=max\n'
+    printf '#   none=<v>|high=<v>|max=<v>\n'
+    printf '#                  — full per-source-bucket matrix\n'
+    printf '#\n'
+    printf 'proxy_effort=%s\n'          "$proxy_choice"
+    printf '# proxy_effort_opus=max         # always max on the opus tier\n'
+    printf '# proxy_effort_sonnet=auto:high # sonnet thinks at minimum\n'
+    printf '# proxy_effort_haiku=off        # let DeepSeek decide for haiku\n'
+    printf '# proxy_effort_small_fast=none  # never reason on the fast tier\n'
+    printf '#\n'
+    printf '# proxy_bind=127.0.0.1\n'
+    printf '# proxy_debug=0   # 1 → log every regime application to stderr\n'
   } > "$CONFIG_FILE"
   chmod 600 "$CONFIG_FILE"
 }
 
+# Interactive opt-in for the reasoning-effort proxy. Echoes the chosen
+# proxy_effort spec to stdout. Defaults to "off" — the proxy is opt-in.
+_cds_prompt_proxy_choice() {
+  {
+    echo
+    echo "Reasoning-effort proxy (optional)"
+    echo "─────────────────────────────────"
+    echo "claude already triggers DeepSeek's default reasoning depth via"
+    echo "/think, /think-hard, /ultrathink — you don't need the proxy for"
+    echo "normal use."
+    echo
+    echo "Enable it if you want to FORCE a specific reasoning regime"
+    echo "regardless of what claude requests:"
+    echo "  • [a] auto:high — always at least default reasoning, even when"
+    echo "        claude wouldn't normally enable thinking"
+    echo "  • [m] auto:max  — maximum reasoning on every request"
+    echo "  • [c] custom    — write the spec yourself (per-tier knobs, etc.)"
+    echo "  • [s] skip      — leave the proxy off (default; recommended)"
+    echo
+  } >&2
+  printf "Choice [s/a/m/c, default s]: " >&2
+  local choice; IFS= read -e -r choice
+  case "${choice,,}" in
+    a)   printf 'auto:high' ;;
+    m)   printf 'auto:max' ;;
+    c)
+      {
+        echo
+        echo "Spec language reference:"
+        echo "  off | auto | auto:<level> | none | high | max | none=<v>|high=<v>|max=<v>"
+        echo "(See --help: REASONING-EFFORT PROXY for the full grammar.)"
+      } >&2
+      printf "Custom proxy_effort: " >&2
+      local custom; IFS= read -e -r custom
+      printf '%s' "${custom:-off}"
+      ;;
+    *)   printf 'off' ;;
+  esac
+}
+
+# Validate a freshly-captured (ref, key) pair against the upstream API
+# before we persist it. On a clear unauth response, offer to retry.
+# Network / advisory failures are not fatal — they emit a one-line note
+# and let the user proceed, since first-run on a flaky network shouldn't
+# block setup.
+_cds_validate_or_warn() {
+  local ref="$1" base="$2" model="$3"
+  local token
+  token=$(secretref_resolve "$ref" 2>/dev/null) || {
+    _cds_warn "could not resolve secret reference '$ref' yet — saving anyway, rerun --rotate-key to fix."
+    return 0
+  }
+  [[ -n "$token" ]] || {
+    _cds_warn "resolved API key is empty for '$ref' — saving anyway, rerun --rotate-key to fix."
+    return 0
+  }
+  local result
+  result=$(_cds_validate_api_key "$token" "$base" "$model")
+  case "$result" in
+    ok)        _cds_log "✓ API key validated against $base." ;;
+    skipped)   _cds_log "(curl not installed — skipping API key liveness check.)" ;;
+    network)   _cds_warn "couldn't reach $base for liveness check (timeout / DNS). Saving anyway." ;;
+    unauth)    return 1 ;;
+    advisory:*) _cds_log "$base returned ${result#advisory:} during liveness check — saving anyway (this may be a model-id mismatch, not a key problem)." ;;
+  esac
+  return 0
+}
+
 prompt_for_key() {
-  local ref
-  ref=$(secretref_prompt "DeepSeek API key for claude-ds")
-  write_config "$ref"
+  local ref attempts=0 proxy_choice
+  while :; do
+    ref=$(secretref_prompt "DeepSeek API key for claude-ds")
+    if _cds_validate_or_warn "$ref" "$DEFAULT_BASE_URL" "$DEFAULT_MODEL"; then
+      proxy_choice=$(_cds_prompt_proxy_choice)
+      write_config "$ref" "$proxy_choice"
+      return 0
+    fi
+    _cds_warn "$DEFAULT_BASE_URL rejected the supplied key (HTTP 401/403)."
+    attempts=$((attempts+1))
+    if [[ "$attempts" -ge 3 ]]; then
+      _cds_warn "saving anyway after 3 attempts — rerun --rotate-key once you have a working key."
+      proxy_choice=$(_cds_prompt_proxy_choice)
+      write_config "$ref" "$proxy_choice"
+      return 0
+    fi
+    printf "Try a different reference? [Y/n]: " >&2
+    local again; IFS= read -e -r again
+    case "$again" in
+      n|N)
+        proxy_choice=$(_cds_prompt_proxy_choice)
+        write_config "$ref" "$proxy_choice"
+        return 0
+        ;;
+    esac
+  done
 }
 
 # ---- handle reset ----------------------------------------------------------
 if [[ "$RESET" -eq 1 ]]; then
-  echo "claude-ds: --reset-password — rotating stored API key reference." >&2
+  _cds_log "--rotate-key — rotating stored API key reference."
   if [[ -f "$CONFIG_FILE" ]]; then
+    # Repair / migrate first so the awk read finds a sane file.
+    if [[ "$(_cds_validate_config_file "$CONFIG_FILE")" == "damaged" ]]; then
+      _cds_repair_config_file "$CONFIG_FILE"
+    fi
+    _cds_migrate_config "$CONFIG_FILE"
     old_ref=$(awk -F= '$1=="api_key_ref"{sub(/^api_key_ref=/,""); print; exit}' "$CONFIG_FILE" || true)
     new_ref=$(secretref_reset_interactive "$old_ref" "DeepSeek API key for claude-ds")
-    write_config "$new_ref"
-    echo "claude-ds:   wrote config $CONFIG_FILE." >&2
+    # Preserve the user's existing proxy_effort choice across rotation —
+    # rotating an API key shouldn't silently flip the proxy back to off.
+    existing_proxy=$(awk -F= '$1=="proxy_effort"{sub(/^proxy_effort=/,""); print; exit}' "$CONFIG_FILE" || true)
+    [[ -z "$existing_proxy" ]] && existing_proxy="off"
+    # Best-effort liveness check on the new ref (not fatal — the user has
+    # already committed to this reference via the interactive flow).
+    _cds_validate_or_warn "$new_ref" "${DEFAULT_BASE_URL}" "$DEFAULT_MODEL" || \
+      _cds_warn "saved despite liveness-check failure — run --doctor for diagnostics."
+    write_config "$new_ref" "$existing_proxy"
+    _cds_log "wrote config $CONFIG_FILE (proxy_effort preserved: $existing_proxy)."
   else
-    echo "claude-ds:   no existing config file at $CONFIG_FILE — running first-run prompt." >&2
+    _cds_log "no existing config file at $CONFIG_FILE — running first-run prompt."
     prompt_for_key
   fi
 elif [[ ! -f "$CONFIG_FILE" ]]; then
   prompt_for_key
+else
+  # Existing config: validate + migrate before we start reading from it.
+  if [[ "$(_cds_validate_config_file "$CONFIG_FILE")" == "damaged" ]]; then
+    _cds_repair_config_file "$CONFIG_FILE"
+  fi
+  _cds_migrate_config "$CONFIG_FILE"
 fi
 
 # ---- load config -----------------------------------------------------------
 api_key_ref=""; model=""; base_url=""
 model_opus=""; model_sonnet=""; model_haiku=""; model_small_fast=""
 capabilities=""; unlock_auto_mode=""
+# Defaults: proxy DISABLED. DeepSeek's compat shim already maps claude's
+# `thinking` block to its native `high` reasoning regime, so the proxy is
+# only valuable to users who want to *force* a specific regime regardless
+# of what claude requested (e.g. always-max, always-no-thinking, or
+# per-tier control). Default to off; first-run prompt offers opt-in.
+# Empty per-tier means "fall through to default".
+proxy_effort="off"
+proxy_effort_opus=""; proxy_effort_sonnet=""; proxy_effort_haiku=""; proxy_effort_small_fast=""
+proxy_strip_thinking=""; proxy_bind=""; proxy_debug=""
 while IFS='=' read -r k v; do
   # Skip comments and blank lines so users can comment out keys with `#` to
   # fall back to the runtime defaults.
@@ -744,19 +1265,147 @@ while IFS='=' read -r k v; do
     \#*|"") continue ;;
   esac
   case "$k" in
-    api_key_ref)      api_key_ref="$v" ;;
-    base_url)         base_url="$v" ;;
-    model)            model="$v" ;;
-    model_opus)       model_opus="$v" ;;
-    model_sonnet)     model_sonnet="$v" ;;
-    model_haiku)      model_haiku="$v" ;;
-    model_small_fast) model_small_fast="$v" ;;
-    capabilities)     capabilities="$v" ;;
-    unlock_auto_mode) unlock_auto_mode="$v" ;;
+    api_key_ref)              api_key_ref="$v" ;;
+    base_url)                 base_url="$v" ;;
+    model)                    model="$v" ;;
+    model_opus)               model_opus="$v" ;;
+    model_sonnet)             model_sonnet="$v" ;;
+    model_haiku)              model_haiku="$v" ;;
+    model_small_fast)         model_small_fast="$v" ;;
+    capabilities)             capabilities="$v" ;;
+    unlock_auto_mode)         unlock_auto_mode="$v" ;;
+    proxy_effort)             proxy_effort="$v" ;;
+    proxy_effort_opus)        proxy_effort_opus="$v" ;;
+    proxy_effort_sonnet)      proxy_effort_sonnet="$v" ;;
+    proxy_effort_haiku)       proxy_effort_haiku="$v" ;;
+    proxy_effort_small_fast)  proxy_effort_small_fast="$v" ;;
+    proxy_strip_thinking)     ;;  # deprecated in v0.6 — proxy now handles strip/preserve via the regime model; ignored
+    proxy_bind)               proxy_bind="$v" ;;
+    proxy_debug)              proxy_debug="$v" ;;
+    _schema)                  ;;  # consumed earlier by migrate_config; ignore here
+    *)                        _cds_warn "unknown config key '$k' on load — preserving on next write but otherwise ignored" ;;
   esac
 done < "$CONFIG_FILE"
 
-[[ -n "$api_key_ref" ]] || { echo "claude-ds: config missing api_key_ref; rerun with --reset-password" >&2; exit 1; }
+# Env-var overrides (useful for one-off invocations without editing config):
+[[ -n "${CLAUDE_DS_PROXY_EFFORT:-}" ]] && proxy_effort="$CLAUDE_DS_PROXY_EFFORT"
+[[ -n "${CLAUDE_DS_PROXY_DEBUG:-}" ]]  && proxy_debug="$CLAUDE_DS_PROXY_DEBUG"
+
+[[ -n "$api_key_ref" ]] || { echo "claude-ds: config missing api_key_ref; rerun with --reset-password or --rotate-key" >&2; exit 1; }
+
+# ---- --doctor: end-to-end diagnostics, then exit ---------------------------
+if [[ "$DOCTOR" -eq 1 ]]; then
+  echo "claude-ds doctor — version $VERSION"
+  echo "──────────────────────────────────"
+  ok()   { printf '  ✓ %s\n' "$*"; }
+  bad()  { printf '  ✗ %s\n' "$*"; }
+  note() { printf '    %s\n' "$*"; }
+
+  # 1. claude on PATH.
+  if command -v claude >/dev/null 2>&1; then
+    ok "claude binary: $(command -v claude)"
+  else
+    bad "claude binary not found on \$PATH"
+    note "→ install Claude Code: https://docs.anthropic.com/claude/code"
+  fi
+
+  # 2. python3 (only relevant when proxy is enabled).
+  if command -v python3 >/dev/null 2>&1; then
+    ok "python3: $(python3 --version 2>&1)"
+  else
+    bad "python3 not found — required for the reasoning-effort proxy"
+    note "→ install python3 (≥3.8), or set proxy_effort=off in $CONFIG_FILE"
+  fi
+
+  # 3. Config file readability.
+  if [[ -r "$CONFIG_FILE" ]]; then
+    ok "config readable: $CONFIG_FILE"
+    note "schema: v$(_cds_read_schema "$CONFIG_FILE") (current is v$CURRENT_SCHEMA)"
+  else
+    bad "config file not readable: $CONFIG_FILE"
+  fi
+
+  # 4. Secret reference resolves.
+  if dr_token=$(secretref_resolve "$api_key_ref" 2>/dev/null) && [[ -n "$dr_token" ]]; then
+    ok "secret reference resolves: $api_key_ref"
+  else
+    bad "could not resolve secret reference: $api_key_ref"
+    note "→ check the upstream store (op/system/infisical), or rerun --rotate-key"
+    dr_token=""
+  fi
+
+  # 5. API key liveness.
+  if [[ -n "$dr_token" ]]; then
+    case "$(_cds_validate_api_key "$dr_token" "${base_url:-$DEFAULT_BASE_URL}" "${model:-$DEFAULT_MODEL}")" in
+      ok)        ok "API key live against ${base_url:-$DEFAULT_BASE_URL}" ;;
+      unauth)    bad "API key rejected (401/403) by ${base_url:-$DEFAULT_BASE_URL}"
+                 note "→ rerun --rotate-key with a current key" ;;
+      network)   bad "could not reach ${base_url:-$DEFAULT_BASE_URL} (timeout / DNS)"
+                 note "→ check your network; this is non-fatal at launch" ;;
+      skipped)   ok "API key liveness check skipped (curl not installed)" ;;
+      advisory:*) bad "API endpoint returned an unexpected status — see --rotate-key" ;;
+    esac
+  fi
+
+  # 6. Proxy script presence (only when proxy is enabled).
+  proxy_active=0
+  case "${proxy_effort:-off}" in off|OFF|"") ;; *) proxy_active=1 ;; esac
+  for v in "$proxy_effort_small_fast" "$proxy_effort_haiku" "$proxy_effort_sonnet" "$proxy_effort_opus"; do
+    case "$v" in ""|off|OFF) ;; *) proxy_active=1 ;; esac
+  done
+  if [[ "$proxy_active" -eq 1 ]]; then
+    _claude_ds_realpath() {
+      local src="$1" dir
+      while [[ -L "$src" ]]; do
+        dir="$(cd -P "$(dirname "$src")" && pwd)"
+        src="$(readlink "$src")"
+        [[ "$src" != /* ]] && src="$dir/$src"
+      done
+      printf '%s\n' "$src"
+    }
+    dr_self="$(_claude_ds_realpath "${BASH_SOURCE[0]}")"
+    dr_dir="$(cd -P "$(dirname "$dr_self")" && pwd)"
+    dr_proxy="$dr_dir/claude-ds-proxy.py"
+    if [[ -f "$dr_proxy" ]]; then
+      ok "proxy script present: $dr_proxy"
+    else
+      bad "proxy script missing: $dr_proxy"
+      note "→ next launch will attempt a one-time download from $PROXY_DOWNLOAD_URL"
+      note "  or copy claude-ds-proxy.py next to claude-ds yourself"
+    fi
+  else
+    ok "proxy disabled (proxy_effort=off, no per-tier overrides) — skipping proxy checks"
+  fi
+
+  # 7. Tier-collision lint preview (only when proxy is enabled).
+  if [[ "$proxy_active" -eq 1 ]]; then
+    case "${unlock_auto_mode:-0}" in
+      1|true|yes|on)
+        dr_o="${model_opus:-claude-opus-4-7}"
+        dr_s="${model_sonnet:-claude-sonnet-4-6}"
+        dr_h="${model_haiku:-claude-haiku-4-5}"
+        dr_f="${model_small_fast:-claude-haiku-4-5}" ;;
+      *)
+        dr_m="${model:-$DEFAULT_MODEL}"
+        dr_o="${model_opus:-$dr_m}"; dr_s="${model_sonnet:-$dr_m}"
+        dr_h="${model_haiku:-$dr_m}"; dr_f="${model_small_fast:-$dr_m}" ;;
+    esac
+    if _cds_lint_collisions "$dr_o" "$dr_s" "$dr_h" "$dr_f" \
+        "$proxy_effort_opus" "$proxy_effort_sonnet" "$proxy_effort_haiku" "$proxy_effort_small_fast" 2>/tmp/_cds_collisions.$$; then
+      if [[ -s /tmp/_cds_collisions.$$ ]]; then
+        bad "tier-spec collisions detected:"
+        sed 's/^/    /' /tmp/_cds_collisions.$$
+      else
+        ok "no tier-spec collisions"
+      fi
+    fi
+    rm -f /tmp/_cds_collisions.$$
+  fi
+
+  echo "──────────────────────────────────"
+  echo "doctor done."
+  exit 0
+fi
 
 token=$(secretref_resolve "$api_key_ref") || { echo "claude-ds: failed to resolve API key from $api_key_ref" >&2; exit 1; }
 [[ -n "$token" ]] || { echo "claude-ds: resolved API key is empty ($api_key_ref)" >&2; exit 1; }
@@ -828,6 +1477,168 @@ fi
 export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
 export CLAUDE_DISABLE_NONSTREAMING_FALLBACK=1
 
+# ---- reasoning-effort proxy ------------------------------------------------
+# Optional local HTTP proxy that injects DeepSeek's `reasoning_effort`
+# parameter into outgoing /v1/messages bodies. Anthropic's API uses
+# `thinking.budget_tokens` for the same idea but on a different wire shape;
+# DeepSeek won't honor it via the compat shim. The proxy bridges the two,
+# so claude's "think hard" / "ultrathink" cues actually drive DeepSeek
+# reasoning depth.
+#
+# The proxy is started only when at least one effort spec is non-empty
+# and not "off". With `proxy_effort=off` and no per-tier overrides set,
+# this block is a no-op and claude talks to DeepSeek directly.
+#
+# Per-tier specs are bound to the *wire-level* model id (the value of
+# ANTHROPIC_DEFAULT_<TIER>_MODEL exported above), not the tier name. If
+# multiple tiers map to the same wire id (the default — DeepSeek is
+# single-tier), the per-tier specs collide and only the last-written
+# wins; the order below is small_fast → haiku → sonnet → opus, so opus
+# wins on collision (matches user expectation that opus is "the"
+# strongest tier).
+
+proxy_bind_val="${proxy_bind:-127.0.0.1}"
+proxy_debug_val="${proxy_debug:-0}"
+
+# Decide whether the proxy is needed at all.
+proxy_needed=0
+case "${proxy_effort:-}" in
+  ""|off|OFF) ;;
+  *) proxy_needed=1 ;;
+esac
+for v in "$proxy_effort_small_fast" "$proxy_effort_haiku" "$proxy_effort_sonnet" "$proxy_effort_opus"; do
+  case "$v" in
+    ""|off|OFF) ;;
+    *) proxy_needed=1 ;;
+  esac
+done
+
+claude_ds_proxy_pid=""
+if [[ "$proxy_needed" -eq 1 ]]; then
+  # Soft-fallback: missing python3 → run with proxy effectively off for
+  # this session, with a clear warning. We do NOT mutate the user's
+  # config — they may install python3 later and want the proxy back on
+  # next invocation. The warning is loud enough that they know.
+  if ! command -v python3 >/dev/null 2>&1; then
+    _cds_warn "python3 not found — running with the reasoning-effort proxy DISABLED for this session."
+    _cds_warn "  install python3 (or set proxy_effort=off in $CONFIG_FILE to silence this)."
+    proxy_needed=0
+  fi
+fi
+if [[ "$proxy_needed" -eq 1 ]]; then
+  # Lint per-tier specs for silent wire-id collisions. Pure inspection;
+  # never blocks execution.
+  _cds_lint_collisions \
+    "${spoof_opus:-$resolved_model}" "${spoof_sonnet:-$resolved_model}" \
+    "${spoof_haiku:-$resolved_model}" "${spoof_small:-$resolved_model}" \
+    "$proxy_effort_opus" "$proxy_effort_sonnet" \
+    "$proxy_effort_haiku" "$proxy_effort_small_fast" 2>&1 || true
+
+  # Build EFFORT_MAP entries in priority-low → priority-high order so the
+  # last write wins on wire-id collisions (opus > sonnet > haiku > small_fast).
+  effort_map=""
+  add_pair() {
+    local wire_id="$1" spec="$2"
+    [[ -z "$spec" || "$spec" == "off" || "$spec" == "OFF" ]] && return 0
+    [[ -n "$effort_map" ]] && effort_map+=";"
+    effort_map+="${wire_id}=${spec}"
+  }
+  add_pair "$ANTHROPIC_SMALL_FAST_MODEL"      "$proxy_effort_small_fast"
+  add_pair "$ANTHROPIC_DEFAULT_HAIKU_MODEL"   "$proxy_effort_haiku"
+  add_pair "$ANTHROPIC_DEFAULT_SONNET_MODEL"  "$proxy_effort_sonnet"
+  add_pair "$ANTHROPIC_DEFAULT_OPUS_MODEL"    "$proxy_effort_opus"
+
+  # If proxy_effort itself is "off" but some per-tier specs are set,
+  # don't pass a default (other models pass through unchanged).
+  case "${proxy_effort:-}" in
+    off|OFF) effort_default="" ;;
+    *)       effort_default="${proxy_effort:-auto}" ;;
+  esac
+
+  # Resolve the wrapper's real on-disk location so the proxy lookup works
+  # when `claude-ds` is symlinked (e.g. `~/.local/bin/claude-ds` →
+  # `~/src/agent-utilities/wrappers/claude-ds/claude-ds`). bash does NOT
+  # canonicalize $BASH_SOURCE, and macOS's BSD `readlink` has no `-f`, so
+  # we chase the symlink chain manually — portable across macOS / Linux
+  # without GNU coreutils.
+  _claude_ds_realpath() {
+    local src="$1" dir
+    while [[ -L "$src" ]]; do
+      dir="$(cd -P "$(dirname "$src")" && pwd)"
+      src="$(readlink "$src")"
+      [[ "$src" != /* ]] && src="$dir/$src"
+    done
+    printf '%s\n' "$src"
+  }
+  _self="$(_claude_ds_realpath "${BASH_SOURCE[0]}")"
+  _self_dir="$(cd -P "$(dirname "$_self")" && pwd)"
+  proxy_script="$_self_dir/claude-ds-proxy.py"
+  # Lazy install: if the proxy is missing, try to fetch it from the same
+  # upstream the wrapper came from. On any failure, soft-fall-back to
+  # proxy-disabled for this session rather than blocking the user.
+  if [[ ! -f "$proxy_script" ]]; then
+    _cds_log "proxy script missing at $proxy_script — attempting one-time download..."
+    case "$(_cds_ensure_proxy_script "$proxy_script")" in
+      downloaded)
+        _cds_log "downloaded proxy script from $PROXY_DOWNLOAD_URL."
+        ;;
+      skipped)
+        _cds_warn "curl not installed and proxy script missing — running with proxy DISABLED."
+        _cds_warn "  install curl, or place claude-ds-proxy.py next to claude-ds, or set proxy_effort=off."
+        proxy_needed=0
+        ;;
+      failed|*)
+        _cds_warn "proxy download failed (network, 404, or write permission) — running with proxy DISABLED."
+        _cds_warn "  fix by re-running with curl available, or place the proxy script next to claude-ds, or set proxy_effort=off."
+        proxy_needed=0
+        ;;
+    esac
+  fi
+fi
+if [[ "$proxy_needed" -eq 1 ]]; then
+
+  # Spawn the proxy with stdout piped back so we can read the bound port
+  # synchronously. The proxy prints the port as its first line, then keeps
+  # serving in the background. We close the stdout pipe after reading the
+  # port so subsequent log writes (debug mode) go to stderr only — the
+  # python child's stderr inherits this script's stderr.
+  proxy_fifo="$(mktemp -u "${TMPDIR:-/tmp}/claude-ds-proxy.XXXXXX")"
+  mkfifo -m 600 "$proxy_fifo"
+
+  UPSTREAM_BASE_URL="$ANTHROPIC_BASE_URL" \
+  EFFORT_MAP="$effort_map" \
+  EFFORT_DEFAULT="$effort_default" \
+  PROXY_BIND="$proxy_bind_val" \
+  PROXY_PORT=0 \
+  PROXY_DEBUG="$proxy_debug_val" \
+    python3 "$proxy_script" >"$proxy_fifo" 2>&2 &
+  claude_ds_proxy_pid=$!
+
+  # Read the port (first line of stdout). 5-second timeout so we fail
+  # fast if the proxy died on startup (e.g. bad spec).
+  proxy_port=""
+  if read -r -t 5 proxy_port < "$proxy_fifo"; then
+    :
+  fi
+  rm -f "$proxy_fifo"
+
+  if [[ -z "$proxy_port" ]] || ! kill -0 "$claude_ds_proxy_pid" 2>/dev/null; then
+    _cds_warn "reasoning-effort proxy failed to start — running with proxy DISABLED for this session."
+    _cds_warn "  rerun with CLAUDE_DS_PROXY_DEBUG=1 to see the python child's startup error."
+    [[ -n "$claude_ds_proxy_pid" ]] && wait "$claude_ds_proxy_pid" 2>/dev/null
+    claude_ds_proxy_pid=""
+    proxy_needed=0
+  else
+    # Repoint claude at the proxy. Upstream URL stays in $ANTHROPIC_BASE_URL
+    # only inside the proxy's env (already exported above for the python
+    # invocation); we now overwrite the var for claude's own env.
+    export ANTHROPIC_BASE_URL="http://${proxy_bind_val}:${proxy_port}"
+
+    # Friendly summary on stderr so users can see the wiring at a glance.
+    _cds_log "reasoning-effort proxy on ${proxy_bind_val}:${proxy_port} → DeepSeek (default=${effort_default:-off}, per-model=${effort_map:-<none>})"
+  fi
+fi
+
 # ---- visual branding (tmux only) ------------------------------------------
 # When running inside tmux, decorate the *pane* (not the status line!) so the
 # user can tell at a glance that this window is a DeepSeek-backed claude even
@@ -879,31 +1690,46 @@ if [[ -n "${TMUX:-}" && -n "${TMUX_PANE:-}" && -z "${CLAUDE_DS_NO_BRANDING:-}" ]
     tmux set -w -t "$ds_brand_window" pane-active-border-style "fg=${ds_brand_color},bg=default,bold"     2>/dev/null || true
     tmux set -w -t "$ds_brand_window" pane-border-format "$ds_brand_format"                               2>/dev/null || true
 
-    # Window-scope options outlive the pane, so restore on exit when the
-    # window is multi-pane. Single-pane windows die with the wrapper and
-    # take their options with them — but the window NAME deserves restoring
-    # in both cases (otherwise re-launching in the same window leaves a
-    # stale 🐋 prefix even after a crash).
-    trap '
-      pane_count=$(tmux display-message -p -t "$ds_brand_window" "#{window_panes}" 2>/dev/null || echo 1)
-      if [[ -n "$ds_brand_orig_name" ]]; then
-        tmux rename-window -t "$ds_brand_window" "$ds_brand_orig_name" 2>/dev/null || true
-      fi
-      if [[ -n "$ds_brand_orig_autorename" ]]; then
-        tmux set -w -t "$ds_brand_window" automatic-rename "$ds_brand_orig_autorename" 2>/dev/null || true
-      else
-        tmux set -wu -t "$ds_brand_window" automatic-rename 2>/dev/null || true
-      fi
-      if [[ "$pane_count" -gt 1 ]]; then
-        tmux set -wu -t "$ds_brand_window" pane-border-status        2>/dev/null || true
-        tmux set -wu -t "$ds_brand_window" pane-border-lines         2>/dev/null || true
-        tmux set -wu -t "$ds_brand_window" pane-border-style         2>/dev/null || true
-        tmux set -wu -t "$ds_brand_window" pane-active-border-style  2>/dev/null || true
-        tmux set -wu -t "$ds_brand_window" pane-border-format        2>/dev/null || true
-      fi
-    ' EXIT
   fi
 fi
+
+# ---- exit cleanup ----------------------------------------------------------
+# Consolidated EXIT trap that:
+#   1. Kills the reasoning-effort proxy (if spawned).
+#   2. Restores tmux window/pane decorations (if applied).
+# `exec`'ing claude replaces this shell, so the trap fires only on the
+# pre-exec failure paths. Once `exec claude` succeeds the proxy is
+# orphaned to its original parent (init/launchd) and lives until claude
+# exits — at which point tmux's pane-death cleanup takes care of any
+# lingering process tree under the same pane group. We *also* set a
+# SIGTERM/SIGINT trap so ctrl-c delivered to this script before exec
+# tears the proxy down cleanly.
+
+claude_ds_cleanup() {
+  if [[ -n "${claude_ds_proxy_pid:-}" ]]; then
+    kill "$claude_ds_proxy_pid" 2>/dev/null || true
+  fi
+  if [[ -n "${ds_brand_window:-}" ]]; then
+    local pane_count
+    pane_count=$(tmux display-message -p -t "$ds_brand_window" '#{window_panes}' 2>/dev/null || echo 1)
+    if [[ -n "${ds_brand_orig_name:-}" ]]; then
+      tmux rename-window -t "$ds_brand_window" "$ds_brand_orig_name" 2>/dev/null || true
+    fi
+    if [[ -n "${ds_brand_orig_autorename:-}" ]]; then
+      tmux set -w -t "$ds_brand_window" automatic-rename "$ds_brand_orig_autorename" 2>/dev/null || true
+    else
+      tmux set -wu -t "$ds_brand_window" automatic-rename 2>/dev/null || true
+    fi
+    if [[ "$pane_count" -gt 1 ]]; then
+      tmux set -wu -t "$ds_brand_window" pane-border-status        2>/dev/null || true
+      tmux set -wu -t "$ds_brand_window" pane-border-lines         2>/dev/null || true
+      tmux set -wu -t "$ds_brand_window" pane-border-style         2>/dev/null || true
+      tmux set -wu -t "$ds_brand_window" pane-active-border-style  2>/dev/null || true
+      tmux set -wu -t "$ds_brand_window" pane-border-format        2>/dev/null || true
+    fi
+  fi
+}
+trap claude_ds_cleanup EXIT INT TERM
 
 # Separator between any claude-ds-owned output above and forwarded claude
 # output below. (Interactive TUI invocations of claude clear the screen, so

--- a/wrappers/claude-ds/claude-ds-proxy.py
+++ b/wrappers/claude-ds/claude-ds-proxy.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+# claude-ds-proxy — request-rewriting proxy that translates Anthropic
+# `thinking.budget_tokens` into the DeepSeek-shaped reasoning regime on
+# outgoing /v1/messages bodies.
+#
+# Spawned by the `claude-ds` shell wrapper. Stdlib-only (Python 3.8+).
+#
+# DeepSeek's compat shim recognises three reasoning regimes:
+#   "none"   — `thinking` block ABSENT, no `reasoning_effort`. No reasoning.
+#   "high"   — `thinking: {"type": "enabled"}` PRESENT, `reasoning_effort`
+#              absent (or =high — same wire effect). DeepSeek's default
+#              reasoning depth.
+#   "max"    — `thinking` PRESENT *and* `reasoning_effort=max`. Maximum
+#              reasoning depth. (Other Anthropic levels — `low`, `medium`,
+#              `minimal`, `xhigh` — are not real DeepSeek regimes; this
+#              proxy collapses them onto the three above.)
+#
+# So the proxy applies a *transformation* (not just an injection):
+#   level=none → strip `thinking`, strip `reasoning_effort`
+#   level=high → ensure `thinking: {type: enabled}` (with the original
+#                budget_tokens preserved if present), strip `reasoning_effort`
+#   level=max  → ensure `thinking: {type: enabled}`, set `reasoning_effort=max`
+#
+# Configuration via environment variables (set by the wrapper):
+#   UPSTREAM_BASE_URL   required. e.g. https://api.deepseek.com/anthropic
+#   PROXY_BIND          default 127.0.0.1
+#   PROXY_PORT          default 0 (kernel-assigned; actual port printed to
+#                       stdout as the first line so the parent can read it)
+#   EFFORT_DEFAULT      spec applied to any model not named in EFFORT_MAP.
+#                       see "Spec language" below. empty = passthrough.
+#   EFFORT_MAP          per-wire-model overrides. semicolon-separated
+#                       `<model>=<spec>` pairs.
+#                       e.g. "claude-opus-4-7=auto;claude-sonnet-4-6=high"
+#   PROXY_DEBUG         "1" to log rewrites/requests to stderr.
+#
+# Spec language (the value side of EFFORT_MAP / EFFORT_DEFAULT):
+#   off            no transformation — pass the body through unchanged.
+#                  (empty string is treated the same.)
+#   none           force the "no reasoning" regime (strip thinking block).
+#   high           force the "default reasoning" regime (thinking enabled,
+#                  no reasoning_effort).
+#   max            force the "maximum reasoning" regime (thinking enabled
+#                  + reasoning_effort=max).
+#   auto           derive the regime from claude's `thinking` block:
+#                    no/disabled thinking          → "none"
+#                    thinking enabled, budget <31k → "high"
+#                    thinking enabled, budget ≥31k → "max"
+#                  (Thresholds align with Claude Code's canned levels:
+#                  `think` ≈ 4k, `think hard` ≈ 10k, `think harder` ≈ 20k,
+#                  `ultrathink` ≈ 31999. ultrathink → max; everything else
+#                  with thinking → high.)
+#   auto:<level>   like auto, but use <level> as the fallback when claude
+#                  sends no thinking block. e.g. `auto:high` ensures
+#                  thinking is always on; `auto:none` is identical to bare
+#                  `auto`.
+#   none=<v>|high=<v>|max=<v>
+#                  full per-source-bucket matrix. each clause is optional;
+#                  unlisted source buckets pass through unchanged.
+#                  e.g. `none=high|high=high|max=max` ≡ `auto:high`.
+#
+# Resolution order on every POST /v1/messages:
+#   1. spec = EFFORT_MAP[model] if present, else EFFORT_DEFAULT
+#   2. if spec is empty/`off` → forward unchanged
+#   3. otherwise resolve spec against the source bucket → target regime
+#   4. apply the regime's transformation to the body
+#
+# Note: the proxy intentionally OVERRIDES any caller-supplied
+# `reasoning_effort`, because Claude Code's `/effort low` / `/effort medium`
+# / `/effort xhigh` send levels DeepSeek doesn't recognise — passing them
+# through unchanged would cause silent 400s or quiet downgrades. To opt
+# out of the override, set the spec to `off` for that model.
+
+import http.client
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
+
+
+# ---------- spec parsing ----------------------------------------------------
+
+# DeepSeek-recognised reasoning regimes. These are the only values a
+# spec can resolve to (plus the implicit "passthrough" for `off`).
+_LEVELS = {"none", "high", "max"}
+# Source-bucket keys (rows of the auto-mapping matrix). The auto-bucket
+# function emits one of these for each request based on claude's
+# `thinking` block.
+_BUCKETS = ("none", "high", "max")
+
+
+def _parse_spec(raw: str):
+    """Parse a spec string into a callable: bucket -> effort_or_none.
+
+    Returns None when the spec disables injection unconditionally."""
+    s = (raw or "").strip()
+    if not s or s.lower() == "off":
+        return None
+    s_low = s.lower()
+    if s_low in _LEVELS:
+        # Constant — same level for every source bucket.
+        def _const(bucket, _s=s_low):
+            _ = bucket
+            return _s
+        return _const
+    if s_low == "auto":
+        # bare `auto` mirrors the source bucket directly: 'none' → strip,
+        # 'high' → enable thinking, 'max' → enable thinking + max effort.
+        return lambda bucket: bucket if bucket in _LEVELS else None
+    if s_low.startswith("auto:"):
+        # `auto:<level>` upgrades the no-thinking case ('none' bucket) to
+        # the named level, while leaving high/max buckets at their bucket
+        # value. Useful for "always at least thinking" (`auto:high`) or
+        # "always full reasoning" (`auto:max`).
+        fallback = s_low.split(":", 1)[1].strip()
+        if fallback not in _LEVELS:
+            raise ValueError(f"auto: fallback must be one of {sorted(_LEVELS)} (got {fallback!r})")
+        def _auto_with_fallback(bucket, _f=fallback):
+            if bucket == "none":
+                return _f
+            return bucket if bucket in _LEVELS else None
+        return _auto_with_fallback
+    # Otherwise, expect a `key=val|key=val|...` matrix.
+    matrix = {}
+    for clause in s.split("|"):
+        clause = clause.strip()
+        if not clause:
+            continue
+        if "=" not in clause:
+            raise ValueError(f"matrix clause missing '=': {clause!r}")
+        k, v = clause.split("=", 1)
+        k, v = k.strip().lower(), v.strip().lower()
+        if k not in _BUCKETS:
+            raise ValueError(f"matrix bucket must be one of {list(_BUCKETS)} (got {k!r})")
+        if v not in _LEVELS and v != "off":
+            raise ValueError(f"matrix value must be a level or 'off' (got {v!r})")
+        if v != "off":
+            matrix[k] = v
+    if not matrix:
+        return None
+    return lambda bucket, _m=matrix: _m.get(bucket)
+
+
+def _parse_map(spec: str) -> dict:
+    """Parse `model=spec;model=spec;...` into {model: resolver}."""
+    out = {}
+    if not spec:
+        return out
+    for pair in spec.split(";"):
+        pair = pair.strip()
+        if not pair or "=" not in pair:
+            continue
+        model, raw_spec = pair.split("=", 1)
+        model = model.strip()
+        if not model:
+            continue
+        out[model] = _parse_spec(raw_spec)
+    return out
+
+
+# ---------- environment / config -------------------------------------------
+
+UPSTREAM = os.environ.get("UPSTREAM_BASE_URL", "")
+if not UPSTREAM:
+    print("claude-ds-proxy: UPSTREAM_BASE_URL is required", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    EFFORT_RESOLVERS = _parse_map(os.environ.get("EFFORT_MAP", ""))
+    DEFAULT_RESOLVER = _parse_spec(os.environ.get("EFFORT_DEFAULT", ""))
+except ValueError as e:
+    print(f"claude-ds-proxy: bad effort spec: {e}", file=sys.stderr)
+    sys.exit(2)
+
+DEBUG = os.environ.get("PROXY_DEBUG", "") == "1"
+
+_up = urlsplit(UPSTREAM)
+UP_SCHEME = _up.scheme
+UP_HOST = _up.hostname or ""
+UP_PORT = _up.port or (443 if UP_SCHEME == "https" else 80)
+UP_PATH_PREFIX = (_up.path or "").rstrip("/")
+
+
+def _log(*args):
+    if DEBUG:
+        print("[claude-ds-proxy]", *args, file=sys.stderr, flush=True)
+
+
+# ---------- request rewriting ----------------------------------------------
+
+_HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _should_inject(method: str, path: str) -> bool:
+    if method != "POST":
+        return False
+    bare = path.split("?", 1)[0].rstrip("/")
+    return bare.endswith("/v1/messages")
+
+
+def _bucket_from_thinking(thinking) -> str:
+    """Return one of 'none' | 'high' | 'max' for a thinking block.
+
+    DeepSeek only distinguishes three reasoning regimes, so the bucket
+    space matches: no thinking → 'none'; thinking enabled with any
+    sub-ultrathink budget → 'high'; thinking enabled with ultrathink-tier
+    budget → 'max'."""
+    if not isinstance(thinking, dict) or thinking.get("type") != "enabled":
+        return "none"
+    try:
+        n = int(thinking.get("budget_tokens", 0) or 0)
+    except (TypeError, ValueError):
+        return "high"
+    return "max" if n >= 31000 else "high"
+
+
+def _apply_regime(obj: dict, regime: str) -> None:
+    """Mutate `obj` in place to match the target DeepSeek regime.
+
+    none — strip both `thinking` and `reasoning_effort` so DeepSeek
+           returns a plain non-reasoning response.
+    high — ensure `thinking: {type: enabled}` (preserving any
+           caller-supplied budget_tokens), strip `reasoning_effort`
+           since DeepSeek treats omission and `=high` as the same wire
+           effect and Anthropic-style values like `low`/`medium` would
+           otherwise be rejected.
+    max  — ensure `thinking: {type: enabled}`, set `reasoning_effort=max`."""
+    if regime == "none":
+        obj.pop("thinking", None)
+        obj.pop("reasoning_effort", None)
+        return
+    # Both `high` and `max` need thinking enabled. Preserve an existing
+    # budget_tokens if present; otherwise omit (DeepSeek handles unbounded).
+    existing = obj.get("thinking")
+    new_thinking: dict = {"type": "enabled"}
+    if isinstance(existing, dict) and "budget_tokens" in existing:
+        new_thinking["budget_tokens"] = existing["budget_tokens"]
+    obj["thinking"] = new_thinking
+    if regime == "high":
+        obj.pop("reasoning_effort", None)
+    elif regime == "max":
+        obj["reasoning_effort"] = "max"
+
+
+def _rewrite_body(body: bytes) -> bytes:
+    try:
+        obj = json.loads(body)
+    except Exception as e:
+        _log(f"body not JSON, passing through ({e})")
+        return body
+    if not isinstance(obj, dict):
+        return body
+
+    model = obj.get("model", "") or ""
+    resolver = EFFORT_RESOLVERS.get(model, DEFAULT_RESOLVER)
+    if resolver is None:
+        _log(f"no effort spec applies to model={model!r}; passing through")
+        return body
+
+    bucket = _bucket_from_thinking(obj.get("thinking"))
+    regime = resolver(bucket)
+    if not regime:
+        _log(f"spec yielded no regime for model={model!r} bucket={bucket!r}; passing through")
+        return body
+
+    incoming_re = obj.get("reasoning_effort", "<absent>")
+    _apply_regime(obj, regime)
+    _log(
+        f"applied regime={regime!r} model={model!r} source-bucket={bucket!r} "
+        f"(was reasoning_effort={incoming_re!r})"
+    )
+    return json.dumps(obj, ensure_ascii=False).encode("utf-8")
+
+
+# ---------- HTTP server -----------------------------------------------------
+
+
+class Proxy(BaseHTTPRequestHandler):
+    # HTTP/1.1 + Connection: close on responses gives us length-by-EOF
+    # framing — the simplest way to forward streaming SSE bodies without
+    # re-encoding chunked transfer.
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format, *args):  # noqa: A002 — match base sig
+        if DEBUG:
+            super().log_message(format, *args)
+
+    def _handle(self):
+        clen = self.headers.get("Content-Length")
+        body = b""
+        if clen:
+            try:
+                body = self.rfile.read(int(clen))
+            except Exception as e:
+                self.send_error(400, f"failed to read request body: {e}")
+                return
+
+        if _should_inject(self.command, self.path) and body:
+            ctype = (self.headers.get("Content-Type") or "").lower()
+            if "json" in ctype:
+                body = _rewrite_body(body)
+
+        fwd_headers = []
+        for h, v in self.headers.items():
+            if h.lower() in _HOP_BY_HOP:
+                continue
+            if h.lower() in ("host", "content-length"):
+                continue
+            fwd_headers.append((h, v))
+        fwd_headers.append(("Host", UP_HOST))
+        if body:
+            fwd_headers.append(("Content-Length", str(len(body))))
+
+        target_path = UP_PATH_PREFIX + self.path
+
+        if UP_SCHEME == "https":
+            conn = http.client.HTTPSConnection(UP_HOST, UP_PORT, timeout=600)
+        else:
+            conn = http.client.HTTPConnection(UP_HOST, UP_PORT, timeout=600)
+
+        try:
+            conn.putrequest(self.command, target_path, skip_host=True, skip_accept_encoding=True)
+            for h, v in fwd_headers:
+                conn.putheader(h, v)
+            conn.endheaders()
+            if body:
+                conn.send(body)
+            resp = conn.getresponse()
+        except Exception as e:
+            _log(f"upstream request failed: {e}")
+            try:
+                self.send_error(502, f"upstream error: {e}")
+            except Exception:
+                pass
+            conn.close()
+            return
+
+        try:
+            self.send_response(resp.status, resp.reason)
+            for h, v in resp.getheaders():
+                hl = h.lower()
+                if hl in _HOP_BY_HOP:
+                    continue
+                if hl == "content-length":
+                    continue
+                self.send_header(h, v)
+            self.send_header("Connection", "close")
+            self.end_headers()
+
+            while True:
+                chunk = resp.read(8192)
+                if not chunk:
+                    break
+                try:
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    _log("client closed connection mid-stream")
+                    break
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    do_GET = _handle
+    do_POST = _handle
+    do_PUT = _handle
+    do_DELETE = _handle
+    do_PATCH = _handle
+    do_OPTIONS = _handle
+    do_HEAD = _handle
+
+
+def _watch_orphan():
+    """Background watchdog: exit when the parent process dies. The wrapper
+    `exec`s claude after spawning us, so our parent stays alive for the
+    duration of the claude session. When claude exits, we get reparented
+    to PID 1 (init/launchd) — that's our cue to shut down."""
+    initial_ppid = os.getppid()
+    while True:
+        time.sleep(2)
+        ppid = os.getppid()
+        if ppid != initial_ppid and ppid == 1:
+            _log("parent died (reparented to init); exiting")
+            os._exit(0)
+
+
+def main():
+    threading.Thread(target=_watch_orphan, daemon=True).start()
+    bind = os.environ.get("PROXY_BIND", "127.0.0.1")
+    port = int(os.environ.get("PROXY_PORT", "0") or "0")
+    server = ThreadingHTTPServer((bind, port), Proxy)
+    actual_port = server.server_address[1]
+    # First line of stdout is the bound port — the parent wrapper reads
+    # it synchronously to know we're ready and which port to point
+    # ANTHROPIC_BASE_URL at.
+    print(actual_port, flush=True)
+    _log(f"listening on {bind}:{actual_port}, upstream={UPSTREAM}")
+    _log(f"per-model resolvers: {sorted(EFFORT_RESOLVERS)}, default-set={DEFAULT_RESOLVER is not None}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

`claude-ds` 0.6.0 — a substantial release that:

1. **Adds a reasoning-effort proxy** (`claude-ds-proxy.py`, Python stdlib) translating Anthropic's `thinking.budget_tokens` into DeepSeek's three actual reasoning regimes (`none` / `high` / `max`).
2. **Makes the wrapper self-healing** so the README becomes reference rather than required reading.
3. **Adds a proper user-facing README** — reviewed by 3 Sonnet agents and 1 (handicapped) Opus agent in competition; verified-correct findings applied.

## What's new for the user

| Before 0.6 | After 0.6 |
|---|---|
| Hand-edit config when schema changes | Auto-migrated forward with `<config>.v<old>.bak` backup |
| Hand-fix config typos | Detected on launch, backed up, parseable keys preserved |
| Hard-fail when proxy script missing | Lazy-fetch from upstream; soft-fallback if fetch fails |
| Hard-fail when python3 missing | Soft-fallback: warn once, run with proxy disabled |
| Bad API key fails on first real call | Liveness-checked on first-run / `--rotate-key` |
| "Did I install everything?" → no answer | `claude-ds --doctor` walks a 7-step checklist |
| Silent per-tier proxy collisions | Linted on launch, colliders named |
| Symlinking required two symlinks | One symlink works (portable readlink loop) |

## Key correctness fix

The earlier proxy draft assumed Anthropic's full level set (`minimal`/`low`/`medium`/`high`) was honoured by DeepSeek's compat shim. Per DeepSeek docs, only **three** wire regimes exist:

- **`none`** — `thinking` absent, no `reasoning_effort`. No reasoning.
- **`high`** — `thinking: {type: enabled}` present, no `reasoning_effort` (or `=high` — same wire effect). DeepSeek's default reasoning depth.
- **`max`** — `thinking` present **and** `reasoning_effort=max`. Maximum reasoning.

The proxy spec language collapses to `{off, none, high, max, auto, auto:<level>, none=v|high=v|max=v}`. Caller-supplied unknown levels are normalised rather than passed through (DeepSeek would silently 400 or downgrade them).

## Proxy is now off by default

DeepSeek already maps claude's `/think`, `/think-hard`, `/ultrathink` natively via the `thinking` block claude already sends. The proxy adds nothing for normal use. Enable it only when you want to **force** a regime regardless of what claude requests (always-max, always-none, per-tier knobs). First-run prompts for an interactive opt-in.

## Test plan

- [x] Syntax / parse checks pass on both files
- [x] `--version` clean output
- [x] Damaged-config recovery: malformed line + unknown key both handled, backup written, repaired config valid
- [x] Schema migration v0 → v1: backup written to `.v0.bak`, `_schema=1` prepended in place
- [x] `--doctor` with proxy disabled: 6 checks, ✓/✗ markers
- [x] `--doctor` with proxy enabled: includes proxy-script presence + tier collision lint
- [x] Lazy proxy install: `curl` failure path soft-falls-back, no config mutation
- [x] Missing python3 path: same soft-fallback
- [x] End-to-end proxy spawn: ultrathink request gets `max` regime applied, thinking block preserved alongside `reasoning_effort=max`, orphan watchdog reaps proxy on claude exit
- [x] All 7 spec-language cases (off, none, high, max, auto, auto:level, matrix) parse + apply correctly

## Notes for review

- The `wrappers/claude-ds/` directory is a pending self-graduation — README's developer-notes section flags this and asks PRs to target this monorepo until it moves.
- `proxy_strip_thinking` config key is now deprecated (silently ignored; strip/preserve is implicit in the regime model).
- Cookies for the README review went to Opus, who caught the per-tier collision under `unlock_auto_mode=1` (haiku and small_fast both map to `claude-haiku-4-5`, breaking the simple "opus wins" mental model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)